### PR TITLE
WIP

### DIFF
--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
@@ -79,7 +79,6 @@ import io.github.agimaulana.radio.feature.stationlist.player.FullPlayer
 import io.github.agimaulana.radio.feature.stationlist.player.MiniPlayer
 import kotlinx.collections.immutable.persistentListOf
 
-private const val EXPANDED_CONTENT_THRESHOLD = 0.2f
 private val HeroBackgroundColor = Color(0xFF1C1A24)
 private const val DarkScrimAlpha = 0.50f
 private const val LightScrimAlpha = 0.82f
@@ -178,6 +177,7 @@ private fun StationListScreen(
             )
         }
     ) {
+<<<<<<< Updated upstream
         StationListContent(
             uiState = uiState,
             listState = listState,
@@ -225,6 +225,20 @@ private fun StationFullPlayer(
             onStop = {
                 onCollapse()
                 onAction(Action.Stop(station))
+=======
+        Scaffold(
+            topBar = {
+                StationListToolbar(
+                    progress = progress,
+                    locationName = uiState.locationName,
+                    filterStationName = uiState.filterStationName,
+                    stationCount = uiState.stations.size,
+                    onSearch = { onAction(Action.Search(it)) },
+                    onRefreshLocation = { onAction(Action.RefreshLocation) },
+                    expandedHeight = expandedHeight,
+                    collapsedHeight = collapsedHeight
+                )
+>>>>>>> Stashed changes
             },
             onCollapse = onCollapse,
             modifier = Modifier.fillMaxWidth()
@@ -303,9 +317,11 @@ private fun StationListNestedScrollConnection(
 @Composable
 private fun StationListToolbar(
     progress: Float,
+    locationName: String,
     filterStationName: String?,
     stationCount: Int,
     onSearch: (String) -> Unit,
+    onRefreshLocation: () -> Unit,
     expandedHeight: Dp,
     collapsedHeight: Dp,
     modifier: Modifier = Modifier
@@ -367,7 +383,7 @@ private fun StationListToolbar(
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .offset(
-                        y = lerp(155.dp, 20.dp, progress)
+                        y = lerp(155.dp, 12.dp, progress)
                     )
             )
 
@@ -377,18 +393,19 @@ private fun StationListToolbar(
                 placeholder = if (progress < 0.5f) "Search your favourite station..." else "Search...",
                 modifier = Modifier
                     .align(Alignment.TopStart)
-                    .padding(start = lerp(0.dp, 95.dp, progress))
-                    .offset(y = lerp(205.dp, 8.dp, progress))
+                    .padding(start = lerp(0.dp, 105.dp, progress))
+                    .offset(y = lerp(205.dp, 12.dp, progress))
                     .fillMaxWidth()
             )
 
-            val featureFlagEnabled = false // not enabled yet
-            if (featureFlagEnabled && progress < EXPANDED_CONTENT_THRESHOLD) {
+            val locationAlpha = (1f - progress * 5f).coerceIn(0f, 1f)
+            if (locationAlpha > 0f) {
                 Row(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .offset(y = lerp(264.dp, 200.dp, progress))
-                        .graphicsLayer { alpha = (1f - progress * 5f).coerceAtLeast(0f) },
+                        .graphicsLayer { alpha = locationAlpha }
+                        .clickable { onRefreshLocation() },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Box(
@@ -399,7 +416,7 @@ private fun StationListToolbar(
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = "Jakarta, Indonesia",
+                        text = locationName,
                         color = RadioTheme.colors.primary,
                         style = RadioTheme.typography.stationTitle.copy(
                             fontSize = 14.sp,
@@ -480,6 +497,7 @@ private fun StationListScreenPreview() {
     PreviewTheme {
         StationListScreen(
             uiState = UiState(
+                locationName = "Jakarta, Indonesia",
                 stations = persistentListOf(
                     Station(
                         serverUuid = "1",
@@ -512,6 +530,7 @@ private fun StationListScreenDarkPreview() {
     PreviewTheme {
         StationListScreen(
             uiState = UiState(
+                locationName = "Jakarta, Indonesia",
                 stations = persistentListOf(
                     Station(
                         serverUuid = "1",

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -83,6 +83,10 @@ class StationListViewModel @Inject constructor(
                 fetchRadioStations()
             }
 
+            Action.RefreshLocation -> {
+                // TODO: Implement actual location refresh logic
+            }
+
             is Action.Search -> {
                 searchJob?.cancel()
                 _uiState.update {
@@ -255,6 +259,7 @@ class StationListViewModel @Inject constructor(
 
     data class UiState(
         val filterStationName: String? = null,
+        val locationName: String = "Jakarta, Indonesia",
         val currentPage: Int = 0,
         val stations: ImmutableList<Station> = persistentListOf(),
         val selectedStation: Station? = null,
@@ -286,6 +291,7 @@ class StationListViewModel @Inject constructor(
 
     sealed interface Action {
         data object LoadMore : Action
+        data object RefreshLocation : Action
         data class Search(val stationName: String): Action
         data class Click(val station: UiState.Station) : Action
         data class Play(val station: UiState.Station) : Action


### PR DESCRIPTION
Based on my audit of the code in the `agi/feat-collapsing-toolbar` branch compared to the specifications in the image, here is the status:

### 1. Hero Background & Branding
**Status:** ✅ Followed (with a note on transparency)

- The `StationListToolbar` uses `R.drawable.collapsing_toolbar_background` which aligns with the "Half-rings" requirement.
- **Texture Peek-through:** The background remains visible when collapsed with an alpha of 0.8 (`1f - progress * 0.2f`), satisfying the requirement that branding peeks through even when collapsed.

### 2. Collapsed Toolbar
**Status:** ⚠️ Partially Followed

- **One Row:** The Title ("24.7 FM") and the Search Bar are both visible when collapsed.
- **Alignment Issue:** In the collapsed state (progress = 1.0):
  - The Title has a Y-offset of 20.dp.
  - The Search Bar has a Y-offset of 8.dp.
  - While they appear side-by-side (due to the Search Bar's 95.dp start padding), they are not perfectly vertically centered with each other. The Search Bar is 48.dp high, so it likely envelopes the title, but a `Row` or matching offsets would be more precise for "one row" alignment.

### 3. Location Chip
**Status:** ❌ Not Followed / Incomplete

- **Visibility:** It is currently hidden behind a hardcoded `featureFlagEnabled = false`.
- **Functionality:** The spec says "Tapping it could open...". The current implementation is a static `Row` without a clickable modifier or any interaction logic.
- **Visuals:** It correctly shows "City name + nearby station count" but only when the toolbar is expanded.

### 4. Now Playing Bar (Miniplayer)
**Status:** ✅ Fully Followed

- **Persistence:** Implemented via `GlassSlidingPlayerLayout` wrapping the screen; it remains pinned at the bottom regardless of scrolling.
- **Tapping:** The MiniPlayer has a clickable `{ playerState.expand() }` modifier.
- **Dragging:** The layout includes a `.draggable` modifier in `GlassSlidingPlayerLayout.kt` that allows users to expand the player by dragging it up, matching your specific note.

### Summary Table

| Feature              | Followed? | Observations                                      |
|----------------------|-----------|---------------------------------------------------|
| Hero Background      | Yes       | Radiates from bottom, visible when collapsed.     |
| Collapsed Toolbar    | Partial   | Title and Search Bar are side-by-side but offsets are slightly mismatched. |
| Location Chip        | No        | Currently disabled and lacks click interaction.   |
| Now Playing Bar      | Yes       | Persistent, supports tap-to-expand and drag-to-expand. |