### PR TITLE
feat: add pinned stations to station list

### DIFF
--- a/.agents/skills/respond-to-pr-reviews/scripts/post_replies.py
+++ b/.agents/skills/respond-to-pr-reviews/scripts/post_replies.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Post replies to PR review comments.
+
+Usage:
+    python3 post_replies.py <owner> <repo> <pr_number> <replies_json>
+
+replies_json: JSON array of {"comment_id": int, "body": str}
+"""
+
+import json
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def read_token() -> str:
+    env_path = Path(".env")
+    if env_path.exists():
+        env = dict(
+            line.split("=", 1)
+            for line in env_path.read_text().splitlines()
+            if "=" in line and not line.startswith("#")
+        )
+        token = env.get("GITHUB_PERSONAL_ACCESS_TOKEN", "").strip()
+        if token:
+            return token
+    return subprocess.check_output(["gh", "auth", "token"], text=True).strip()
+
+
+def main() -> None:
+    token = read_token()
+    owner, repo, pr_number = sys.argv[1], sys.argv[2], sys.argv[3]
+    replies = json.loads(sys.argv[4])
+
+    for reply in replies:
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}"
+            f"/pulls/{pr_number}/comments/{reply['comment_id']}/replies"
+        )
+        data = json.dumps({"body": reply["body"]}).encode()
+        request = urllib.request.Request(
+            url,
+            data=data,
+            method="POST",
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github.v3+json",
+                "Content-Type": "application/json",
+            },
+        )
+        status = urllib.request.urlopen(request).status
+        print(f"[{status}] comment {reply['comment_id']}: {reply['body'][:60]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/core/network/src/main/kotlin/io/github/agimaulana/radio/core/network/RetrofitBuilderFactory.kt
+++ b/core/network/src/main/kotlin/io/github/agimaulana/radio/core/network/RetrofitBuilderFactory.kt
@@ -1,7 +1,6 @@
 package io.github.agimaulana.radio.core.network
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -9,11 +8,9 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 class RetrofitBuilderFactory {
     fun create(
         baseUrl: String,
+        moshi: Moshi,
         okHttpClient: OkHttpClient = OkHttpClient.Builder().build(),
     ): Retrofit.Builder {
-        val moshi = Moshi.Builder()
-            .add(KotlinJsonAdapterFactory())
-            .build()
         return Retrofit.Builder()
             .baseUrl(baseUrl)
             .client(okHttpClient)

--- a/core/network/src/main/kotlin/io/github/agimaulana/radio/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/io/github/agimaulana/radio/core/network/di/NetworkModule.kt
@@ -1,5 +1,7 @@
 package io.github.agimaulana.radio.core.network.di
 
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -8,13 +10,23 @@ import io.github.agimaulana.radio.core.network.RetrofitBuilderFactory
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
     @Provides
-    fun provideRetrofit(): Retrofit {
+    @Singleton
+    fun provideMoshi(): Moshi {
+        return Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(moshi: Moshi): Retrofit {
         val logging = HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BODY
         }
@@ -24,6 +36,7 @@ object NetworkModule {
         return RetrofitBuilderFactory()
             .create(
                 baseUrl = "https://all.api.radio-browser.info/",
+                moshi = moshi,
                 okHttpClient = okHttpClient,
             )
             .build()

--- a/core/network/test/src/main/kotlin/io/github/agimaulana/radio/core/network/test/TestApiRule.kt
+++ b/core/network/test/src/main/kotlin/io/github/agimaulana/radio/core/network/test/TestApiRule.kt
@@ -1,5 +1,6 @@
 package io.github.agimaulana.radio.core.network.test
 
+import com.squareup.moshi.Moshi
 import io.github.agimaulana.radio.core.network.RetrofitBuilderFactory
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -23,7 +24,8 @@ class TestApiRule(
         retrofit = RetrofitBuilderFactory()
             .create(
                 baseUrl = baseUrl,
-                okHttpClient = OkHttpClient.Builder().build()
+                okHttpClient = OkHttpClient.Builder().build(),
+                moshi = Moshi.Builder().build()
             )
             .build()
     }

--- a/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/repository/PinnedStationRepository.kt
+++ b/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/repository/PinnedStationRepository.kt
@@ -9,3 +9,7 @@ interface PinnedStationRepository {
     suspend fun unpinStation(stationUuid: String)
     suspend fun isPinned(stationUuid: String): Boolean
 }
+
+class PinnedStationLimitReachedException(
+    val maxPins: Int
+) : IllegalStateException("Pinned stations are limited to $maxPins items")

--- a/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/repository/PinnedStationRepository.kt
+++ b/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/repository/PinnedStationRepository.kt
@@ -1,0 +1,11 @@
+package io.github.agimaulana.radio.domain.api.repository
+
+import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import kotlinx.coroutines.flow.Flow
+
+interface PinnedStationRepository {
+    fun getPinnedStations(): Flow<List<RadioStation>>
+    suspend fun pinStation(station: RadioStation)
+    suspend fun unpinStation(stationUuid: String)
+    suspend fun isPinned(stationUuid: String): Boolean
+}

--- a/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/usecase/GetPinnedStationsUseCase.kt
+++ b/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/usecase/GetPinnedStationsUseCase.kt
@@ -1,0 +1,8 @@
+package io.github.agimaulana.radio.domain.api.usecase
+
+import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import kotlinx.coroutines.flow.Flow
+
+interface GetPinnedStationsUseCase {
+    fun execute(): Flow<List<RadioStation>>
+}

--- a/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/usecase/PinStationUseCase.kt
+++ b/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/usecase/PinStationUseCase.kt
@@ -1,0 +1,7 @@
+package io.github.agimaulana.radio.domain.api.usecase
+
+import io.github.agimaulana.radio.domain.api.entity.RadioStation
+
+interface PinStationUseCase {
+    suspend fun execute(station: RadioStation)
+}

--- a/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/usecase/UnpinStationUseCase.kt
+++ b/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/usecase/UnpinStationUseCase.kt
@@ -1,0 +1,5 @@
+package io.github.agimaulana.radio.domain.api.usecase
+
+interface UnpinStationUseCase {
+    suspend fun execute(stationUuid: String)
+}

--- a/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/GetPinnedStationsUseCaseImpl.kt
+++ b/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/GetPinnedStationsUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package io.github.agimaulana.radio.domain.impl
+
+import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.repository.PinnedStationRepository
+import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetPinnedStationsUseCaseImpl @Inject constructor(
+    private val repository: PinnedStationRepository
+) : GetPinnedStationsUseCase {
+    override fun execute(): Flow<List<RadioStation>> {
+        return repository.getPinnedStations()
+    }
+}

--- a/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/PinStationUseCaseImpl.kt
+++ b/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/PinStationUseCaseImpl.kt
@@ -1,0 +1,14 @@
+package io.github.agimaulana.radio.domain.impl
+
+import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.repository.PinnedStationRepository
+import io.github.agimaulana.radio.domain.api.usecase.PinStationUseCase
+import javax.inject.Inject
+
+class PinStationUseCaseImpl @Inject constructor(
+    private val repository: PinnedStationRepository
+) : PinStationUseCase {
+    override suspend fun execute(station: RadioStation) {
+        repository.pinStation(station)
+    }
+}

--- a/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/UnpinStationUseCaseImpl.kt
+++ b/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/UnpinStationUseCaseImpl.kt
@@ -1,0 +1,13 @@
+package io.github.agimaulana.radio.domain.impl
+
+import io.github.agimaulana.radio.domain.api.repository.PinnedStationRepository
+import io.github.agimaulana.radio.domain.api.usecase.UnpinStationUseCase
+import javax.inject.Inject
+
+class UnpinStationUseCaseImpl @Inject constructor(
+    private val repository: PinnedStationRepository
+) : UnpinStationUseCase {
+    override suspend fun execute(stationUuid: String) {
+        repository.unpinStation(stationUuid)
+    }
+}

--- a/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/di/UseCaseModule.kt
+++ b/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/di/UseCaseModule.kt
@@ -4,10 +4,16 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
+import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
+import io.github.agimaulana.radio.domain.api.usecase.PinStationUseCase
+import io.github.agimaulana.radio.domain.api.usecase.UnpinStationUseCase
+import io.github.agimaulana.radio.domain.impl.GetPinnedStationsUseCaseImpl
 import io.github.agimaulana.radio.domain.impl.GetRadioStationUseCaseImpl
 import io.github.agimaulana.radio.domain.impl.GetRadioStationsUseCaseImpl
+import io.github.agimaulana.radio.domain.impl.PinStationUseCaseImpl
+import io.github.agimaulana.radio.domain.impl.UnpinStationUseCaseImpl
 
 @Module
 @InstallIn(ViewModelComponent::class)
@@ -18,4 +24,13 @@ interface UseCaseModule {
 
     @Binds
     fun bindGetRadioStationUseCase(impl: GetRadioStationUseCaseImpl): GetRadioStationUseCase
+
+    @Binds
+    fun bindPinStationUseCase(impl: PinStationUseCaseImpl): PinStationUseCase
+
+    @Binds
+    fun bindUnpinStationUseCase(impl: UnpinStationUseCaseImpl): UnpinStationUseCase
+
+    @Binds
+    fun bindGetPinnedStationsUseCase(impl: GetPinnedStationsUseCaseImpl): GetPinnedStationsUseCase
 }

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
@@ -2,67 +2,42 @@ package io.github.agimaulana.radio.feature.stationlist
 
 import android.app.Activity
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.basicMarquee
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
-import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -77,18 +52,14 @@ import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiSta
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
 import io.github.agimaulana.radio.feature.stationlist.component.LazyRadioStationList
 import io.github.agimaulana.radio.feature.stationlist.component.LocationPermissionBottomSheet
+import io.github.agimaulana.radio.feature.stationlist.component.StationContextMenu
 import io.github.agimaulana.radio.feature.stationlist.player.BufferingIcon
 import io.github.agimaulana.radio.feature.stationlist.player.FullPlayer
 import io.github.agimaulana.radio.feature.stationlist.player.MiniPlayer
 import kotlinx.collections.immutable.persistentListOf
-import timber.log.Timber
+import kotlinx.coroutines.launch
 
-private const val EXPANDED_CONTENT_THRESHOLD = 0.2f
-private val HeroBackgroundColor = Color(0xFF1C1A24)
-private const val DarkScrimAlpha = 0.50f
-private const val LightScrimAlpha = 0.82f
-
-private data class ToolbarDimensions(
+internal data class ToolbarDimensions(
     val expandedHeight: Dp,
     val collapsedHeight: Dp,
     val progress: Float
@@ -101,10 +72,15 @@ fun StationListRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val playerState = rememberGlassPlayerState(peekHeight = 80.dp)
+    val density = LocalDensity.current
+    val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val toolbarDimensions = rememberToolbarDimensions(
+        density = density,
+        statusBarPadding = statusBarPadding,
+        hasPinnedStations = uiState.pinnedStations.isNotEmpty()
+    )
+    val contextMenuState = rememberStationContextMenuState()
 
-    // Provide an explicit callback so the permission state can be resolved from the
-    // ActivityResult callback (the source of truth) — this avoids races with
-    // snapshot-based permission checks on some OEM devices.
     fun resolveLocationPermission(isGranted: Boolean) {
         viewModel.onAction(Action.OnLocationPermissionGranted(isGranted))
     }
@@ -128,10 +104,6 @@ fun StationListRoute(
         )
     }
 
-    // Safeguard for OEMs or race conditions where the ActivityResult
-    // callback isn't delivered on cold start. If permission is granted
-    // but the ViewModel hasn't recorded that fact, dispatch the resolved
-    // permission.
     LaunchedEffect(locationPermissionState.allGranted, uiState.locationPermissionResolved) {
         if (locationPermissionState.allGranted && !uiState.locationPermissionResolved) {
             resolveLocationPermission(isGranted = true)
@@ -141,6 +113,8 @@ fun StationListRoute(
     StationListScreen(
         uiState = uiState,
         playerState = playerState,
+        toolbarDimensions = toolbarDimensions,
+        contextMenuState = contextMenuState,
         onAction = viewModel::onAction,
         showLocationPermissionSheet = uiState.showLocationPermissionSheet,
         onLaunchLocationPermissionRequest = {
@@ -157,6 +131,8 @@ fun StationListRoute(
 private fun StationListScreen(
     uiState: UiState,
     playerState: GlassPlayerState,
+    toolbarDimensions: ToolbarDimensionsHelper,
+    contextMenuState: StationContextMenuState,
     showLocationPermissionSheet: Boolean,
     onLaunchLocationPermissionRequest: () -> Unit,
     onDismissLocationPermission: () -> Unit,
@@ -164,7 +140,8 @@ private fun StationListScreen(
     onAction: (Action) -> Unit = {},
 ) {
     val listState = rememberLazyListState()
-    val density = LocalDensity.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     if (showLocationPermissionSheet) {
         LocationPermissionBottomSheet(
@@ -173,72 +150,69 @@ private fun StationListScreen(
         )
     }
 
-    val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-    val dims = calculateToolbarDimensions(density, statusBarPadding)
-
     UpdateSystemBars()
 
-    val nestedScrollConnection = remember(dims) {
+    val nestedScrollConnection = remember(toolbarDimensions, listState) {
         StationListNestedScrollConnection(
             onScroll = { delta ->
-                dims.onScroll(delta)
+                toolbarDimensions.onScroll(delta)
             },
             canScrollDown = { listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0 }
         )
     }
 
-    GlassSlidingPlayerLayout(
-        state = playerState,
-        modifier = modifier.fillMaxSize(),
-        miniPlayerContent = {
-            StationMiniPlayer(uiState.selectedStation, onAction, playerState)
-        },
-        fullPlayerContent = { progress ->
-            StationFullPlayer(progress, uiState, onAction, playerState)
+    Box(modifier = modifier.fillMaxSize()) {
+        GlassSlidingPlayerLayout(
+            state = playerState,
+            modifier = Modifier.fillMaxSize(),
+            miniPlayerContent = {
+                StationMiniPlayer(uiState.selectedStation, onAction, playerState)
+            },
+            fullPlayerContent = { progress ->
+                StationFullPlayer(progress, uiState, onAction, playerState)
+            }
+        ) {
+            StationListContent(
+                uiState = uiState,
+                listState = listState,
+                dims = toolbarDimensions.toData(),
+                nestedScrollConnection = nestedScrollConnection,
+                snackbarHostState = snackbarHostState,
+                onAction = onAction,
+                onLongClick = { station ->
+                    contextMenuState.show(station)
+                }
+            )
         }
-    ) {
-        StationListContent(uiState, listState, dims.toData(), nestedScrollConnection, onAction)
+
+        StationContextMenu(
+            showMenu = contextMenuState.showMenu,
+            station = contextMenuState.station,
+            useBottomSheet = contextMenuState.useBottomSheet,
+            onDismiss = contextMenuState::dismiss,
+            onAction = { action ->
+                if (action is Action.UnpinStation) {
+                    val stationToUnpin = contextMenuState.station
+                    onAction(action)
+                    if (stationToUnpin != null) {
+                        scope.launch {
+                            val result = snackbarHostState.showSnackbar(
+                                message = "Removed ${stationToUnpin.name}",
+                                actionLabel = "Undo",
+                                duration = androidx.compose.material3.SnackbarDuration.Short
+                            )
+                            if (result == SnackbarResult.ActionPerformed) {
+                                onAction(Action.PinStation(stationToUnpin))
+                            }
+                        }
+                    }
+                } else {
+                    onAction(action)
+                }
+                contextMenuState.dismiss()
+            }
+        )
     }
-}
-
-@Composable
-private fun calculateToolbarDimensions(
-    density: Density,
-    statusBarPadding: Dp
-): ToolbarDimensionsHelper {
-    val expandedHeight = 300.dp + statusBarPadding
-    val collapsedHeight = 64.dp + statusBarPadding
-    val expandedHeightPx = with(density) { expandedHeight.toPx() }
-    val collapsedHeightPx = with(density) { collapsedHeight.toPx() }
-    val toolbarHeightRangePx = expandedHeightPx - collapsedHeightPx
-
-    var toolbarOffsetPx by rememberSaveable { mutableStateOf(0f) }
-
-    val progress = if (toolbarHeightRangePx > 0f) {
-        (toolbarOffsetPx / toolbarHeightRangePx).coerceIn(0f, 1f)
-    } else {
-        0f
-    }
-
-    return ToolbarDimensionsHelper(
-        expandedHeight,
-        collapsedHeight,
-        progress,
-        onScroll = { delta ->
-            val oldOffset = toolbarOffsetPx
-            toolbarOffsetPx = (toolbarOffsetPx - delta).coerceIn(0f, toolbarHeightRangePx)
-            oldOffset - toolbarOffsetPx
-        }
-    )
-}
-
-private class ToolbarDimensionsHelper(
-    val expandedHeight: Dp,
-    val collapsedHeight: Dp,
-    val progress: Float,
-    val onScroll: (Float) -> Float
-) {
-    fun toData() = ToolbarDimensions(expandedHeight, collapsedHeight, progress)
 }
 
 @Composable
@@ -308,7 +282,9 @@ private fun StationListContent(
     listState: LazyListState,
     dims: ToolbarDimensions,
     nestedScrollConnection: NestedScrollConnection,
+    snackbarHostState: SnackbarHostState,
     onAction: (Action) -> Unit,
+    onLongClick: (Station) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -318,6 +294,7 @@ private fun StationListContent(
                 onSearch = { onAction(Action.Search(it)) }
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.background
     ) { innerPadding ->
         if (uiState.isLoading && uiState.stations.isEmpty()) {
@@ -336,8 +313,10 @@ private fun StationListContent(
         } else {
             LazyRadioStationList(
                 stations = uiState.stations,
+                pinnedStations = uiState.pinnedStations,
                 listState = listState,
                 onClick = { onAction(Action.Click(it)) },
+                onLongClick = onLongClick,
                 onReachEnd = { onAction(Action.LoadMore) },
                 contentPadding = PaddingValues(
                     top = lerp(dims.expandedHeight, dims.collapsedHeight, dims.progress) + 16.dp,
@@ -372,200 +351,6 @@ private fun StationListNestedScrollConnection(
     }
 }
 
-@Composable
-private fun StationListToolbar(
-    dims: ToolbarDimensions,
-    uiState: UiState,
-    onSearch: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val currentHeight = lerp(dims.expandedHeight, dims.collapsedHeight, dims.progress)
-
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(currentHeight)
-            .background(HeroBackgroundColor)
-    ) {
-        ToolbarBackground(dims.expandedHeight, dims.progress)
-
-        val isLight = luminance(MaterialTheme.colorScheme.background) > 0.5f
-        val scrimAlpha = if (isLight) LightScrimAlpha else DarkScrimAlpha
-
-        ToolbarScrim(scrimAlpha)
-        ToolbarContent(dims.progress, uiState, onSearch)
-    }
-}
-
-private fun luminance(color: Color): Float =
-    0.2126f * color.red + 0.7152f * color.green + 0.0722f * color.blue
-
-@Composable
-private fun ToolbarBackground(expandedHeight: Dp, progress: Float) {
-    Image(
-        painter = painterResource(id = R.drawable.collapsing_toolbar_background),
-        contentDescription = null,
-        contentScale = ContentScale.Crop,
-        alignment = Alignment.BottomCenter,
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(expandedHeight)
-            .graphicsLayer { alpha = 1f - progress * 0.2f }
-    )
-}
-
-@Composable
-private fun ToolbarScrim(scrimAlpha: Float) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(
-                Brush.verticalGradient(
-                    colorStops = arrayOf(
-                        0.00f to Color.Black.copy(alpha = 0f),
-                        0.50f to Color.Black.copy(alpha = scrimAlpha * 0.6f),
-                        1.00f to Color.Black.copy(alpha = scrimAlpha * 0.85f),
-                    )
-                )
-            )
-    )
-}
-
-@Composable
-private fun ToolbarContent(
-    progress: Float,
-    uiState: UiState,
-    onSearch: (String) -> Unit
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .statusBarsPadding()
-            .padding(horizontal = 16.dp)
-    ) {
-        val titleSize = (32 * (1 - progress) + 20 * progress).sp
-
-        Text(
-            text = "24.7 FM",
-            style = RadioTheme.typography.stationTitle.copy(
-                fontSize = titleSize,
-                fontWeight = FontWeight.Bold,
-                color = Color.White
-            ),
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .offset(y = lerp(155.dp, 20.dp, progress))
-        )
-
-        CustomSearchBar(
-            value = uiState.filterStationName.orEmpty(),
-            onValueChange = onSearch,
-            placeholder = if (progress < 0.5f) "Search your favourite station..." else "Search...",
-            modifier = Modifier
-                .align(Alignment.TopStart)
-                .padding(start = lerp(0.dp, 95.dp, progress))
-                .offset(y = lerp(205.dp, 8.dp, progress))
-                .fillMaxWidth()
-        )
-
-        if (progress < EXPANDED_CONTENT_THRESHOLD && uiState.locationName != null) {
-            LocationLabel(
-                locationName = uiState.locationName,
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .offset(y = lerp(264.dp, 200.dp, progress))
-                    .graphicsLayer { alpha = (1f - progress * 5f).coerceAtLeast(0f) }
-            )
-        }
-    }
-}
-
-@Composable
-private fun LocationLabel(
-    locationName: String,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(
-            modifier = Modifier
-                .size(8.dp)
-                .clip(CircleShape)
-                .background(RadioTheme.colors.primary)
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = locationName,
-            color = RadioTheme.colors.primary,
-            style = RadioTheme.typography.stationTitle.copy(
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Bold
-            ),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.basicMarquee(
-                iterations = Int.MAX_VALUE
-            )
-        )
-    }
-}
-
-@Composable
-private fun CustomSearchBar(
-    value: String,
-    onValueChange: (String) -> Unit,
-    placeholder: String,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .height(48.dp)
-            .clip(RoundedCornerShape(12.dp))
-            .background(Color.White.copy(alpha = 0.1f))
-            .border(1.dp, Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
-            .padding(horizontal = 12.dp),
-        contentAlignment = Alignment.CenterStart
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_search),
-                contentDescription = null,
-                tint = RadioTheme.colors.primary,
-                modifier = Modifier.size(18.dp)
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Box(modifier = Modifier.weight(1f)) {
-                if (value.isEmpty()) {
-                    Text(
-                        text = placeholder,
-                        color = Color.White.copy(alpha = 0.5f),
-                        style = RadioTheme.typography.stationTitle.copy(
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Normal
-                        )
-                    )
-                }
-                BasicTextField(
-                    value = value,
-                    onValueChange = onValueChange,
-                    textStyle = RadioTheme.typography.stationTitle.copy(
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Normal,
-                        color = Color.White
-                    ),
-                    cursorBrush = SolidColor(RadioTheme.colors.primary),
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        }
-    }
-}
-
 @Preview(showBackground = true)
 @Composable
 private fun StationListScreenPreview() {
@@ -587,6 +372,12 @@ private fun StationListScreenPreview() {
                 )
             ),
             playerState = rememberGlassPlayerState(peekHeight = 80.dp),
+            toolbarDimensions = rememberToolbarDimensions(
+                density = LocalDensity.current,
+                statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding(),
+                hasPinnedStations = false
+            ),
+            contextMenuState = rememberStationContextMenuState(),
             showLocationPermissionSheet = false,
             onLaunchLocationPermissionRequest = {},
             onDismissLocationPermission = {},

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -26,7 +25,6 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -43,7 +41,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.agimaulana.radio.core.design.GlassPlayerState
 import io.github.agimaulana.radio.core.design.GlassSlidingPlayerLayout
-import io.github.agimaulana.radio.core.design.RadioTheme
 import io.github.agimaulana.radio.core.design.rememberGlassPlayerState
 import io.github.agimaulana.radio.core.design.rememberMultiplePermissionsState
 import io.github.agimaulana.radio.core.design.theme.PreviewTheme
@@ -53,7 +50,6 @@ import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiSta
 import io.github.agimaulana.radio.feature.stationlist.component.LazyRadioStationList
 import io.github.agimaulana.radio.feature.stationlist.component.LocationPermissionBottomSheet
 import io.github.agimaulana.radio.feature.stationlist.component.StationContextMenu
-import io.github.agimaulana.radio.feature.stationlist.player.BufferingIcon
 import io.github.agimaulana.radio.feature.stationlist.player.FullPlayer
 import io.github.agimaulana.radio.feature.stationlist.player.MiniPlayer
 import kotlinx.collections.immutable.persistentListOf
@@ -297,36 +293,23 @@ private fun StationListContent(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.background
     ) { innerPadding ->
-        if (uiState.isLoading && uiState.stations.isEmpty()) {
-            Box(
-                modifier = Modifier
-                    .padding(innerPadding)
-                    .fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                BufferingIcon(
-                    modifier = Modifier.size(96.dp),
-                    tint = RadioTheme.colors.primary,
-                    tweenDurationMillis = 1500,
-                )
-            }
-        } else {
-            LazyRadioStationList(
-                stations = uiState.stations,
-                pinnedStations = uiState.pinnedStations,
-                listState = listState,
-                onClick = { onAction(Action.Click(it)) },
-                onLongClick = onLongClick,
-                onReachEnd = { onAction(Action.LoadMore) },
-                contentPadding = PaddingValues(
-                    top = lerp(dims.expandedHeight, dims.collapsedHeight, dims.progress) + 16.dp,
-                    bottom = innerPadding.calculateBottomPadding() + 80.dp,
-                ),
-                modifier = Modifier
-                    .fillMaxSize()
-                    .nestedScroll(nestedScrollConnection)
-            )
-        }
+        LazyRadioStationList(
+            stations = uiState.stations,
+            pinnedStations = uiState.pinnedStations,
+            isPinnedStationsLoading = uiState.isPinnedStationsLoading,
+            isStationsLoading = uiState.isStationsLoading,
+            listState = listState,
+            onClick = { onAction(Action.Click(it)) },
+            onLongClick = onLongClick,
+            onReachEnd = { onAction(Action.LoadMore) },
+            contentPadding = PaddingValues(
+                top = lerp(dims.expandedHeight, dims.collapsedHeight, dims.progress) + 16.dp,
+                bottom = innerPadding.calculateBottomPadding() + 80.dp,
+            ),
+            modifier = Modifier
+                .fillMaxSize()
+                .nestedScroll(nestedScrollConnection)
+        )
     }
 }
 

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
@@ -321,8 +321,6 @@ private fun StationListContent(
                 contentPadding = PaddingValues(
                     top = lerp(dims.expandedHeight, dims.collapsedHeight, dims.progress) + 16.dp,
                     bottom = innerPadding.calculateBottomPadding() + 80.dp,
-                    start = 16.dp,
-                    end = 16.dp
                 ),
                 modifier = Modifier
                     .fillMaxSize()

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.Preview
@@ -45,6 +46,7 @@ import io.github.agimaulana.radio.core.design.rememberGlassPlayerState
 import io.github.agimaulana.radio.core.design.rememberMultiplePermissionsState
 import io.github.agimaulana.radio.core.design.theme.PreviewTheme
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.Action
+import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiEvent
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
 import io.github.agimaulana.radio.feature.stationlist.component.LazyRadioStationList
@@ -52,6 +54,8 @@ import io.github.agimaulana.radio.feature.stationlist.component.LocationPermissi
 import io.github.agimaulana.radio.feature.stationlist.component.StationContextMenu
 import io.github.agimaulana.radio.feature.stationlist.player.FullPlayer
 import io.github.agimaulana.radio.feature.stationlist.player.MiniPlayer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 
@@ -72,8 +76,7 @@ fun StationListRoute(
     val statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     val toolbarDimensions = rememberToolbarDimensions(
         density = density,
-        statusBarPadding = statusBarPadding,
-        hasPinnedStations = uiState.pinnedStations.isNotEmpty()
+        statusBarPadding = statusBarPadding
     )
     val contextMenuState = rememberStationContextMenuState()
 
@@ -112,6 +115,7 @@ fun StationListRoute(
         toolbarDimensions = toolbarDimensions,
         contextMenuState = contextMenuState,
         onAction = viewModel::onAction,
+        eventFlow = viewModel.uiEvent,
         showLocationPermissionSheet = uiState.showLocationPermissionSheet,
         onLaunchLocationPermissionRequest = {
             locationPermissionState.launchPermissionRequest()
@@ -132,12 +136,15 @@ private fun StationListScreen(
     showLocationPermissionSheet: Boolean,
     onLaunchLocationPermissionRequest: () -> Unit,
     onDismissLocationPermission: () -> Unit,
+    eventFlow: Flow<UiEvent>,
     modifier: Modifier = Modifier,
     onAction: (Action) -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val undoLabel = remember(context) { context.getString(R.string.undo) }
 
     if (showLocationPermissionSheet) {
         LocationPermissionBottomSheet(
@@ -147,6 +154,18 @@ private fun StationListScreen(
     }
 
     UpdateSystemBars()
+
+    LaunchedEffect(eventFlow, context) {
+        eventFlow.collect { event ->
+            when (event) {
+                is UiEvent.ShowPinnedLimitReached -> {
+                    snackbarHostState.showSnackbar(
+                        message = context.getString(R.string.pinned_limit_reached_message, event.maxPins)
+                    )
+                }
+            }
+        }
+    }
 
     val nestedScrollConnection = remember(toolbarDimensions, listState) {
         StationListNestedScrollConnection(
@@ -193,8 +212,8 @@ private fun StationListScreen(
                     if (stationToUnpin != null) {
                         scope.launch {
                             val result = snackbarHostState.showSnackbar(
-                                message = "Removed ${stationToUnpin.name}",
-                                actionLabel = "Undo",
+                                message = context.getString(R.string.pinned_removed_message, stationToUnpin.name),
+                                actionLabel = undoLabel,
                                 duration = androidx.compose.material3.SnackbarDuration.Short
                             )
                             if (result == SnackbarResult.ActionPerformed) {
@@ -355,13 +374,13 @@ private fun StationListScreenPreview() {
             playerState = rememberGlassPlayerState(peekHeight = 80.dp),
             toolbarDimensions = rememberToolbarDimensions(
                 density = LocalDensity.current,
-                statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding(),
-                hasPinnedStations = false
+                statusBarPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
             ),
             contextMenuState = rememberStationContextMenuState(),
             showLocationPermissionSheet = false,
             onLaunchLocationPermissionRequest = {},
             onDismissLocationPermission = {},
+            eventFlow = emptyFlow(),
         )
     }
 }

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreenState.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreenState.kt
@@ -14,10 +14,9 @@ import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiSta
 @Composable
 internal fun rememberToolbarDimensions(
     density: Density,
-    statusBarPadding: Dp,
-    hasPinnedStations: Boolean
+    statusBarPadding: Dp
 ): ToolbarDimensionsHelper {
-    val expandedHeight = (if (hasPinnedStations) 320.dp else 320.dp) + statusBarPadding
+    val expandedHeight = 320.dp + statusBarPadding
     val collapsedHeight = 64.dp + statusBarPadding
     val expandedHeightPx = with(density) { expandedHeight.toPx() }
     val collapsedHeightPx = with(density) { collapsedHeight.toPx() }
@@ -67,9 +66,9 @@ internal class StationContextMenuState(
     var useBottomSheet by mutableStateOf(useBottomSheet)
         private set
 
-    fun show(station: Station) {
+    fun show(station: Station, useBottomSheet: Boolean = true) {
         this.station = station
-        useBottomSheet = true
+        this.useBottomSheet = useBottomSheet
         showMenu = true
     }
 

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreenState.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreenState.kt
@@ -1,0 +1,84 @@
+package io.github.agimaulana.radio.feature.stationlist
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
+
+@Composable
+internal fun rememberToolbarDimensions(
+    density: Density,
+    statusBarPadding: Dp,
+    hasPinnedStations: Boolean
+): ToolbarDimensionsHelper {
+    val expandedHeight = (if (hasPinnedStations) 320.dp else 320.dp) + statusBarPadding
+    val collapsedHeight = 64.dp + statusBarPadding
+    val expandedHeightPx = with(density) { expandedHeight.toPx() }
+    val collapsedHeightPx = with(density) { collapsedHeight.toPx() }
+    val toolbarHeightRangePx = expandedHeightPx - collapsedHeightPx
+
+    var toolbarOffsetPx by remember { mutableStateOf(0f) }
+
+    val progress = if (toolbarHeightRangePx > 0f) {
+        (toolbarOffsetPx / toolbarHeightRangePx).coerceIn(0f, 1f)
+    } else {
+        0f
+    }
+
+    return ToolbarDimensionsHelper(
+        expandedHeight = expandedHeight,
+        collapsedHeight = collapsedHeight,
+        progress = progress,
+        onScroll = { delta ->
+            val oldOffset = toolbarOffsetPx
+            toolbarOffsetPx = (toolbarOffsetPx - delta).coerceIn(0f, toolbarHeightRangePx)
+            oldOffset - toolbarOffsetPx
+        }
+    )
+}
+
+internal class ToolbarDimensionsHelper(
+    val expandedHeight: Dp,
+    val collapsedHeight: Dp,
+    val progress: Float,
+    val onScroll: (Float) -> Float
+) {
+    fun toData() = ToolbarDimensions(expandedHeight, collapsedHeight, progress)
+}
+
+@Stable
+internal class StationContextMenuState(
+    station: Station? = null,
+    showMenu: Boolean = false,
+    useBottomSheet: Boolean = true,
+) {
+    var station by mutableStateOf(station)
+        private set
+
+    var showMenu by mutableStateOf(showMenu)
+        private set
+
+    var useBottomSheet by mutableStateOf(useBottomSheet)
+        private set
+
+    fun show(station: Station) {
+        this.station = station
+        useBottomSheet = true
+        showMenu = true
+    }
+
+    fun dismiss() {
+        showMenu = false
+    }
+}
+
+@Composable
+internal fun rememberStationContextMenuState(): StationContextMenuState {
+    return remember { StationContextMenuState() }
+}

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListToolbar.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListToolbar.kt
@@ -1,0 +1,295 @@
+package io.github.agimaulana.radio.feature.stationlist
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import androidx.compose.ui.unit.sp
+import io.github.agimaulana.radio.core.design.RadioTheme
+import io.github.agimaulana.radio.core.design.theme.PreviewTheme
+import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState
+import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
+import kotlinx.collections.immutable.persistentListOf
+
+private val HeroBackgroundColor = Color(0xFF1C1A24)
+private const val DarkScrimAlpha = 0.50f
+private const val LightScrimAlpha = 0.82f
+private const val EXPANDED_CONTENT_THRESHOLD = 0.2f
+private val LocationOffsetExpanded = 278.dp
+
+@Composable
+internal fun StationListToolbar(
+    dims: ToolbarDimensions,
+    uiState: UiState,
+    onSearch: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val currentHeight = lerp(dims.expandedHeight, dims.collapsedHeight, dims.progress)
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(currentHeight)
+            .background(HeroBackgroundColor)
+    ) {
+        ToolbarBackground(dims.expandedHeight, dims.progress)
+
+        val isLight = luminance(MaterialTheme.colorScheme.background) > 0.5f
+        val scrimAlpha = if (isLight) LightScrimAlpha else DarkScrimAlpha
+
+        ToolbarScrim(scrimAlpha)
+        ToolbarContent(
+            progress = dims.progress,
+            uiState = uiState,
+            onSearch = onSearch
+        )
+    }
+}
+
+private fun luminance(color: Color): Float =
+    0.2126f * color.red + 0.7152f * color.green + 0.0722f * color.blue
+
+@Composable
+private fun ToolbarBackground(expandedHeight: Dp, progress: Float) {
+    Image(
+        painter = painterResource(id = R.drawable.collapsing_toolbar_background),
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        alignment = Alignment.BottomCenter,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(expandedHeight)
+            .graphicsLayer { alpha = 1f - progress * 0.2f }
+    )
+}
+
+@Composable
+private fun ToolbarScrim(scrimAlpha: Float) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0.00f to Color.Black.copy(alpha = 0f),
+                        0.50f to Color.Black.copy(alpha = scrimAlpha * 0.6f),
+                        1.00f to Color.Black.copy(alpha = scrimAlpha * 0.85f),
+                    )
+                )
+            )
+    )
+}
+
+@Composable
+private fun ToolbarContent(
+    progress: Float,
+    uiState: UiState,
+    onSearch: (String) -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp)
+    ) {
+        val titleSize = (32 * (1 - progress) + 20 * progress).sp
+
+        Text(
+            text = "24.7 FM",
+            style = RadioTheme.typography.stationTitle.copy(
+                fontSize = titleSize,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
+            ),
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .offset(y = lerp(155.dp, 20.dp, progress))
+        )
+
+        CustomSearchBar(
+            value = uiState.filterStationName.orEmpty(),
+            onValueChange = onSearch,
+            placeholder = if (progress < 0.5f) "Search your favourite station..." else "Search...",
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(start = lerp(0.dp, 95.dp, progress))
+                .offset(y = lerp(205.dp, 8.dp, progress))
+                .fillMaxWidth()
+        )
+
+        if (progress < EXPANDED_CONTENT_THRESHOLD && uiState.locationName != null) {
+            LocationLabel(
+                locationName = uiState.locationName,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset(
+                        y = lerp(
+                            LocationOffsetExpanded,
+                            220.dp,
+                            progress
+                        )
+                    )
+                    .graphicsLayer { alpha = (1f - progress * 5f).coerceAtLeast(0f) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun LocationLabel(
+    locationName: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(RadioTheme.colors.primary)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = locationName,
+            color = RadioTheme.colors.primary,
+            style = RadioTheme.typography.stationTitle.copy(
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold
+            ),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.basicMarquee(
+                iterations = Int.MAX_VALUE
+            )
+        )
+    }
+}
+
+@Composable
+private fun CustomSearchBar(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .height(48.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color.White.copy(alpha = 0.1f))
+            .border(1.dp, Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+            .padding(horizontal = 12.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_search),
+                contentDescription = null,
+                tint = RadioTheme.colors.primary,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Box(modifier = Modifier.weight(1f)) {
+                if (value.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        color = Color.White.copy(alpha = 0.5f),
+                        style = RadioTheme.typography.stationTitle.copy(
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Normal
+                        )
+                    )
+                }
+                BasicTextField(
+                    value = value,
+                    onValueChange = onValueChange,
+                    textStyle = RadioTheme.typography.stationTitle.copy(
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Normal,
+                        color = Color.White
+                    ),
+                    cursorBrush = SolidColor(RadioTheme.colors.primary),
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true, backgroundColor = 0xFF111111)
+@Composable
+private fun StationListToolbarPreview() {
+    PreviewTheme {
+        StationListToolbar(
+            dims = ToolbarDimensions(
+                expandedHeight = 404.dp,
+                collapsedHeight = 88.dp,
+                progress = 0f
+            ),
+            uiState = UiState(
+                filterStationName = "",
+                locationName = "Jakarta, Indonesia",
+                pinnedStations = persistentListOf(
+                    Station(
+                        serverUuid = "1",
+                        name = "Most 105.8 FM Jakarta",
+                        genre = "90s",
+                        imageUrl = "",
+                        streamUrl = "",
+                        isBuffering = false,
+                        isPlaying = false,
+                        isPinned = true
+                    ),
+                    Station(
+                        serverUuid = "2",
+                        name = "Prambors",
+                        genre = "Top 40",
+                        imageUrl = "",
+                        streamUrl = "",
+                        isBuffering = false,
+                        isPlaying = false,
+                        isPinned = true
+                    )
+                )
+            ),
+            onSearch = {}
+        )
+    }
+}

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -80,6 +80,7 @@ class StationListViewModel @Inject constructor(
                 val pinnedUuids = pinned.map { it.stationUuid }.toSet()
                 _uiState.update { state ->
                     state.copy(
+                        isPinnedStationsLoading = false,
                         pinnedStations = pinned.map { it.toUiStateStation(pinnedUuids) }.toImmutableList(),
                         stations = state.stations.map { it.copy(isPinned = it.serverUuid in pinnedUuids) }.toPersistentList()
                     )
@@ -228,7 +229,7 @@ class StationListViewModel @Inject constructor(
 
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
+            _uiState.update { it.copy(isStationsLoading = true) }
             try {
                 val nextPage = _uiState.value.currentPage + 1
                 val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
@@ -246,12 +247,12 @@ class StationListViewModel @Inject constructor(
                         currentPage = nextPage,
                         stations = (it.stations + fetchedStations).toPersistentList(),
                         hasMorePages = fetchedStations.isNotEmpty() && fetchedStations.size >= PAGE_SIZE,
-                        isLoading = false
+                        isStationsLoading = false
                     )
                 }
             } catch (e: Exception) {
                 Timber.tag("StationListViewModel").e(e, "Error fetching radio stations")
-                _uiState.update { it.copy(isLoading = false) }
+                _uiState.update { it.copy(isStationsLoading = false) }
             }
         }
     }
@@ -307,7 +308,8 @@ class StationListViewModel @Inject constructor(
         val pinnedStations: ImmutableList<Station> = persistentListOf(),
         val selectedStation: Station? = null,
         val hasMorePages: Boolean = true,
-        val isLoading: Boolean = true,
+        val isPinnedStationsLoading: Boolean = true,
+        val isStationsLoading: Boolean = true,
         val playerColors: PlayerColors = PlayerColors(
             Color(0xFF1C1A24),
             Color(0xFF3a1040),

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -13,13 +13,17 @@ import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
+import io.github.agimaulana.radio.domain.api.usecase.PinStationUseCase
+import io.github.agimaulana.radio.domain.api.usecase.UnpinStationUseCase
 import io.github.agimaulana.radio.feature.stationlist.location.LocationProvider
 import io.github.agimaulana.radio.feature.stationlist.player.PlayerColors
 import io.github.agimaulana.radio.feature.stationlist.player.extractPlayerColors
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -34,6 +38,9 @@ import javax.inject.Inject
 class StationListViewModel @Inject constructor(
     private val getRadioStationsUseCase: GetRadioStationsUseCase,
     private val getRadioStationUseCase: GetRadioStationUseCase,
+    private val getPinnedStationsUseCase: GetPinnedStationsUseCase,
+    private val pinStationUseCase: PinStationUseCase,
+    private val unpinStationUseCase: UnpinStationUseCase,
     private val radioPlayerControllerFactory: RadioPlayerControllerFactory,
     private val stationListTracker: StationListTracker,
     private val locationProvider: LocationProvider,
@@ -45,8 +52,9 @@ class StationListViewModel @Inject constructor(
     private var radioPlayerController: RadioPlayerController? = null
     private var searchJob: Job? = null
     private var fetchJob: Job? = null
+    private var pinnedStationsJob: Job? = null
 
-fun init(
+    fun init(
         hasLocationPermission: Boolean = false,
         hasAskedPermission: Boolean = false,
         shouldShowRationale: Boolean = false
@@ -62,13 +70,29 @@ fun init(
             }
             restoreSelectedStation()
         }
+        observePinnedStations()
+    }
+
+    private fun observePinnedStations() {
+        pinnedStationsJob?.cancel()
+        pinnedStationsJob = viewModelScope.launch {
+            getPinnedStationsUseCase.execute().collect { pinned ->
+                val pinnedUuids = pinned.map { it.stationUuid }.toSet()
+                _uiState.update { state ->
+                    state.copy(
+                        pinnedStations = pinned.map { it.toUiStateStation(pinnedUuids) }.toImmutableList(),
+                        stations = state.stations.map { it.copy(isPinned = it.serverUuid in pinnedUuids) }.toPersistentList()
+                    )
+                }
+            }
+        }
     }
 
     private suspend fun restoreSelectedStation() {
         val mediaId = radioPlayerController?.currentMediaId ?: return
         if (mediaId.isNotEmpty()) {
             val station = getRadioStationUseCase.execute(mediaId)
-            val uiStation = station.toUiStateStation().copy(isPlaying = radioPlayerController?.isPlaying == true)
+            val uiStation = station.toUiStateStation(emptySet()).copy(isPlaying = radioPlayerController?.isPlaying == true)
             _uiState.update { it.copy(selectedStation = uiStation) }
             updatePlayerColors(uiStation.imageUrl)
         }
@@ -103,8 +127,21 @@ fun init(
             is Action.ExpandPlayer -> trackPlayerEvent(action.source, true)
             is Action.CollapsePlayer -> trackPlayerEvent(action.source, false)
             is Action.OnLocationPermissionGranted -> handleLocationPermissionGranted(action.isGranted)
-            // RequestLocationPermission action removed: permission requests are initiated from the UI
-            // via rememberMultiplePermissionsState.launchPermissionRequest() and resolved via ActivityResult.
+            is Action.PinStation -> handlePinStation(action.station)
+            is Action.UnpinStation -> handleUnpinStation(action.stationUuid)
+        }
+    }
+
+    private fun handlePinStation(station: UiState.Station) {
+        viewModelScope.launch {
+            val domainStation = getRadioStationUseCase.execute(station.serverUuid) ?: return@launch
+            pinStationUseCase.execute(domainStation)
+        }
+    }
+
+    private fun handleUnpinStation(stationUuid: String) {
+        viewModelScope.launch {
+            unpinStationUseCase.execute(stationUuid)
         }
     }
 
@@ -194,6 +231,7 @@ fun init(
             _uiState.update { it.copy(isLoading = true) }
             try {
                 val nextPage = _uiState.value.currentPage + 1
+                val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
                 val fetchedStations = getRadioStationsUseCase.execute(
                     page = nextPage,
                     searchName = _uiState.value.filterStationName,
@@ -201,7 +239,7 @@ fun init(
                 ).map {
                     val isCurrentlyPlaying = (radioPlayerController?.currentMediaId == it.stationUuid)
                             && (radioPlayerController?.isPlaying == true)
-                    it.toUiStateStation().copy(isPlaying = isCurrentlyPlaying)
+                    it.toUiStateStation(pinnedUuids).copy(isPlaying = isCurrentlyPlaying)
                 }.toPersistentList()
                 _uiState.update {
                     it.copy(
@@ -230,15 +268,21 @@ fun init(
                     stations = it.stations.togglePlayingStateForStations(
                         targetUuid = radioPlayerController?.currentMediaId.orEmpty(),
                         isPlaying = playbackEvent.isPlaying
-                    ))
+                    ),
+                    pinnedStations = it.pinnedStations.togglePlayingStateForStations(
+                        targetUuid = radioPlayerController?.currentMediaId.orEmpty(),
+                        isPlaying = playbackEvent.isPlaying
+                    ).toImmutableList()
+                )
             }
             is PlaybackEvent.StateChanged -> _uiState.update {
                 it.copy(selectedStation = station?.copy(isBuffering = playbackEvent.state == PlaybackState.BUFFERING))
             }
             is PlaybackEvent.MediaItemTransition -> playbackEvent.mediaId?.let { mediaId ->
                 viewModelScope.launch {
+                    val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
                     val s = getRadioStationUseCase.execute(mediaId)
-                    val uiStation = s.toUiStateStation().copy(
+                    val uiStation = s.toUiStateStation(pinnedUuids).copy(
                         isPlaying = radioPlayerController?.isPlaying == true,
                         isBuffering = station?.isBuffering ?: false
                     )
@@ -260,6 +304,7 @@ fun init(
         val filterStationName: String? = null,
         val currentPage: Int = 0,
         val stations: ImmutableList<Station> = persistentListOf(),
+        val pinnedStations: ImmutableList<Station> = persistentListOf(),
         val selectedStation: Station? = null,
         val hasMorePages: Boolean = true,
         val isLoading: Boolean = true,
@@ -268,7 +313,9 @@ fun init(
             Color(0xFF3a1040),
             Color(0xFF0e0c14)
         ),
-        val featureFlag: FeatureFlag = FeatureFlag(),
+        val featureFlag: FeatureFlag = FeatureFlag(
+            isFavoriteEnabled = true,
+        ),
         val locationName: String? = null,
         val currentPosition: GeoLatLong? = null,
         val locationPermissionResolved: Boolean = false,
@@ -281,7 +328,8 @@ fun init(
             val imageUrl: String,
             val streamUrl: String,
             val isBuffering: Boolean,
-            val isPlaying: Boolean
+            val isPlaying: Boolean,
+            val isPinned: Boolean = false,
         )
         data class FeatureFlag(
             val isMoreMenuEnabled: Boolean = false,
@@ -300,7 +348,8 @@ fun init(
         data class ExpandPlayer(val source: String) : Action
         data class CollapsePlayer(val source: String) : Action
         data class OnLocationPermissionGranted(val isGranted: Boolean) : Action
-        // RequestLocationPermission removed — kept permission flow in the UI layer
+        data class PinStation(val station: UiState.Station) : Action
+        data class UnpinStation(val stationUuid: String) : Action
     }
 
     companion object {
@@ -309,14 +358,15 @@ fun init(
     }
 }
 
-private fun RadioStation.toUiStateStation() = StationListViewModel.UiState.Station(
+private fun RadioStation.toUiStateStation(pinnedUuids: Set<String>) = StationListViewModel.UiState.Station(
     serverUuid = stationUuid,
     name = name,
     genre = tags.getOrNull(0).orEmpty(),
     imageUrl = imageUrl,
     streamUrl = url,
     isBuffering = false,
-    isPlaying = false
+    isPlaying = false,
+    isPinned = stationUuid in pinnedUuids
 )
 
 private fun StationListViewModel.UiState.Station.toRadioMediaItem() = RadioMediaItem(

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -13,6 +13,7 @@ import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.repository.PinnedStationLimitReachedException
 import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
@@ -27,7 +28,9 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -48,6 +51,8 @@ class StationListViewModel @Inject constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(UiState())
     val uiState = _uiState.asStateFlow()
+    private val _uiEvent = MutableSharedFlow<UiEvent>()
+    val uiEvent = _uiEvent.asSharedFlow()
 
     private var radioPlayerController: RadioPlayerController? = null
     private var searchJob: Job? = null
@@ -136,7 +141,11 @@ class StationListViewModel @Inject constructor(
     private fun handlePinStation(station: UiState.Station) {
         viewModelScope.launch {
             val domainStation = getRadioStationUseCase.execute(station.serverUuid) ?: return@launch
-            pinStationUseCase.execute(domainStation)
+            try {
+                pinStationUseCase.execute(domainStation)
+            } catch (exception: PinnedStationLimitReachedException) {
+                _uiEvent.emit(UiEvent.ShowPinnedLimitReached(exception.maxPins))
+            }
         }
     }
 
@@ -352,6 +361,10 @@ class StationListViewModel @Inject constructor(
         data class OnLocationPermissionGranted(val isGranted: Boolean) : Action
         data class PinStation(val station: UiState.Station) : Action
         data class UnpinStation(val stationUuid: String) : Action
+    }
+
+    sealed interface UiEvent {
+        data class ShowPinnedLimitReached(val maxPins: Int) : UiEvent
     }
 
     companion object {

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
@@ -1,23 +1,28 @@
 package io.github.agimaulana.radio.feature.stationlist.component
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.material3.contentColorFor
+import io.github.agimaulana.radio.core.design.RadioTheme
+import io.github.agimaulana.radio.feature.stationlist.player.BufferingIcon
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
 import kotlinx.collections.immutable.ImmutableList
 
@@ -25,6 +30,8 @@ import kotlinx.collections.immutable.ImmutableList
 internal fun LazyRadioStationList(
     stations: ImmutableList<Station>,
     pinnedStations: ImmutableList<Station>,
+    isPinnedStationsLoading: Boolean,
+    isStationsLoading: Boolean,
     onClick: (Station) -> Unit,
     onLongClick: (Station) -> Unit,
     modifier: Modifier = Modifier,
@@ -53,14 +60,21 @@ internal fun LazyRadioStationList(
         contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        if (pinnedStations.isNotEmpty()) {
+        if (isPinnedStationsLoading || pinnedStations.isNotEmpty()) {
             item {
-                PinnedStationRow(
-                    pinnedStations = pinnedStations,
-                    onStationClick = onClick,
-                    onStationLongClick = onLongClick,
-                    modifier = Modifier.padding(bottom = 8.dp)
-                )
+                if (isPinnedStationsLoading && pinnedStations.isEmpty()) {
+                    SectionLoading(
+                        label = "PINNED",
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                } else {
+                    PinnedStationRow(
+                        pinnedStations = pinnedStations,
+                        onStationClick = onClick,
+                        onStationLongClick = onLongClick,
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                }
             }
         }
         item {
@@ -78,16 +92,60 @@ internal fun LazyRadioStationList(
                 )
             )
         }
-        items(stations, key = { it.serverUuid }) {
-            StationTile(
-                station = it,
-                onClick = { onClick(it) },
-                onLongClick = { onLongClick(it) },
-                modifier = Modifier.padding(
-                    start = 16.dp,
-                    end = 16.dp
+        if (isStationsLoading && stations.isEmpty()) {
+            item {
+                SectionLoading(
+                    label = null,
+                    modifier = Modifier.padding(horizontal = 16.dp)
                 )
-            )
+            }
+        } else {
+            items(stations, key = { it.serverUuid }) {
+                StationTile(
+                    station = it,
+                    onClick = { onClick(it) },
+                    onLongClick = { onLongClick(it) },
+                    modifier = Modifier.padding(
+                        start = 16.dp,
+                        end = 16.dp
+                    )
+                )
+            }
         }
+        if (isStationsLoading && stations.isNotEmpty()) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 12.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    BufferingIcon(
+                        modifier = Modifier.size(32.dp),
+                        tint = RadioTheme.colors.primary,
+                        tweenDurationMillis = 1500,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLoading(
+    label: String?,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        BufferingIcon(
+            modifier = Modifier.size(if (label == null) 64.dp else 40.dp),
+            tint = RadioTheme.colors.primary,
+            tweenDurationMillis = 1500,
+        )
     }
 }

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
@@ -71,14 +71,22 @@ internal fun LazyRadioStationList(
                     color = sectionLabelColor,
                     letterSpacing = 1.5.sp
                 ),
-                modifier = Modifier.padding(bottom = 8.dp)
+                modifier = Modifier.padding(
+                    bottom = 8.dp,
+                    start = 16.dp,
+                    end = 16.dp
+                )
             )
         }
         items(stations, key = { it.serverUuid }) {
             StationTile(
                 station = it,
                 onClick = { onClick(it) },
-                onLongClick = { onLongClick(it) }
+                onLongClick = { onLongClick(it) },
+                modifier = Modifier.padding(
+                    start = 16.dp,
+                    end = 16.dp
+                )
             )
         }
     }

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
@@ -18,10 +18,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.agimaulana.radio.core.design.RadioTheme
+import io.github.agimaulana.radio.feature.stationlist.R
 import io.github.agimaulana.radio.feature.stationlist.player.BufferingIcon
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
 import kotlinx.collections.immutable.ImmutableList
@@ -64,7 +66,7 @@ internal fun LazyRadioStationList(
             item {
                 if (isPinnedStationsLoading && pinnedStations.isEmpty()) {
                     SectionLoading(
-                        label = "PINNED",
+                        label = stringResource(R.string.pinned_station_row),
                         modifier = Modifier.padding(bottom = 8.dp)
                     )
                 } else {
@@ -79,7 +81,7 @@ internal fun LazyRadioStationList(
         }
         item {
             Text(
-                text = "ALL STATIONS",
+                text = stringResource(R.string.all_stations_list),
                 style = MaterialTheme.typography.labelLarge.copy(
                     fontWeight = FontWeight.Bold,
                     color = sectionLabelColor,

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
@@ -2,27 +2,38 @@ package io.github.agimaulana.radio.feature.stationlist.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.contentColorFor
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 internal fun LazyRadioStationList(
     stations: ImmutableList<Station>,
+    pinnedStations: ImmutableList<Station>,
     onClick: (Station) -> Unit,
+    onLongClick: (Station) -> Unit,
     modifier: Modifier = Modifier,
     listState: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     onReachEnd: () -> Unit = {},
 ) {
+    val sectionLabelColor = contentColorFor(MaterialTheme.colorScheme.background).copy(alpha = 0.72f)
+
     LaunchedEffect(listState) {
         snapshotFlow {
             val layoutInfo = listState.layoutInfo
@@ -42,10 +53,32 @@ internal fun LazyRadioStationList(
         contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        items(stations) {
+        if (pinnedStations.isNotEmpty()) {
+            item {
+                PinnedStationRow(
+                    pinnedStations = pinnedStations,
+                    onStationClick = onClick,
+                    onStationLongClick = onLongClick,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+            }
+        }
+        item {
+            Text(
+                text = "ALL STATIONS",
+                style = MaterialTheme.typography.labelLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = sectionLabelColor,
+                    letterSpacing = 1.5.sp
+                ),
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+        items(stations, key = { it.serverUuid }) {
             StationTile(
                 station = it,
-                onClick = { onClick(it) }
+                onClick = { onClick(it) },
+                onLongClick = { onLongClick(it) }
             )
         }
     }

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/PinnedStationRow.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/PinnedStationRow.kt
@@ -1,0 +1,184 @@
+package io.github.agimaulana.radio.feature.stationlist.component
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
+import io.github.agimaulana.radio.core.design.theme.PreviewTheme
+import io.github.agimaulana.radio.feature.stationlist.R
+import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+internal fun PinnedStationRow(
+    pinnedStations: ImmutableList<Station>,
+    onStationClick: (Station) -> Unit,
+    onStationLongClick: (Station) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_star_filled),
+                contentDescription = null,
+                tint = Color(0xFFFF4081),
+                modifier = Modifier.size(14.dp)
+            )
+            Text(
+                text = "PINNED",
+                style = MaterialTheme.typography.labelLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = contentColorFor(MaterialTheme.colorScheme.background).copy(alpha = 0.72f),
+                    letterSpacing = 1.5.sp
+                )
+            )
+        }
+
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            items(pinnedStations, key = { it.serverUuid }) { station ->
+                PinnedStationChip(
+                    station = station,
+                    onClick = { onStationClick(station) },
+                    onLongClick = { onStationLongClick(station) }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun PinnedStationChip(
+    station: Station,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .width(80.dp)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(72.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(Color.White.copy(alpha = 0.1f))
+                .then(
+                    if (station.isPlaying) {
+                        Modifier.border(2.dp, Color(0xFFFF4081), RoundedCornerShape(20.dp))
+                    } else Modifier
+                )
+        ) {
+            Image(
+                painter = rememberAsyncImagePainter(
+                    model = station.imageUrl,
+                    placeholder = painterResource(id = R.drawable.station_default),
+                    error = painterResource(id = R.drawable.station_default)
+                ),
+                contentDescription = station.name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+
+            // Star badge overlay
+            Icon(
+                painter = painterResource(id = R.drawable.ic_star_filled),
+                contentDescription = null,
+                tint = Color(0xFFFF4081),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(4.dp)
+                    .size(12.dp)
+            )
+        }
+        Text(
+            text = station.name,
+            style = MaterialTheme.typography.labelSmall.copy(
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+                color = contentColorFor(MaterialTheme.colorScheme.background).copy(alpha = 0.8f)
+            ),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PinnedStationRowPreview() {
+    PreviewTheme {
+        PinnedStationRow(
+            pinnedStations = persistentListOf(
+                Station(
+                    serverUuid = "1",
+                    name = "Classic FM",
+                    genre = "Classical",
+                    imageUrl = "",
+                    streamUrl = "",
+                    isBuffering = false,
+                    isPlaying = true,
+                    isPinned = true
+                ),
+                Station(
+                    serverUuid = "2",
+                    name = "Jazz Radio",
+                    genre = "Jazz",
+                    imageUrl = "",
+                    streamUrl = "",
+                    isBuffering = false,
+                    isPlaying = false,
+                    isPinned = true
+                )
+            ),
+            onStationClick = {},
+            onStationLongClick = {}
+        )
+    }
+}

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/PinnedStationRow.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/PinnedStationRow.kt
@@ -21,15 +21,16 @@ import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.agimaulana.radio.core.design.RadioTheme
 import io.github.agimaulana.radio.core.design.theme.PreviewTheme
 import io.github.agimaulana.radio.feature.stationlist.R
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
@@ -52,11 +53,11 @@ internal fun PinnedStationRow(
             Icon(
                 painter = painterResource(id = R.drawable.ic_star_filled),
                 contentDescription = null,
-                tint = Color(0xFFFF4081),
+                tint = RadioTheme.colors.primary,
                 modifier = Modifier.size(14.dp)
             )
             Text(
-                text = "PINNED",
+                text = stringResource(id = R.string.pinned_station_row),
                 style = MaterialTheme.typography.labelLarge.copy(
                     fontWeight = FontWeight.Bold,
                     color = contentColorFor(MaterialTheme.colorScheme.background).copy(alpha = 0.72f),
@@ -103,7 +104,7 @@ private fun PinnedStationChip(
                 .size(72.dp)
                 .then(
                     if (station.isPlaying) {
-                        Modifier.border(2.dp, Color(0xFFFF4081), RoundedCornerShape(20.dp))
+                        Modifier.border(2.dp, RadioTheme.colors.ring, RoundedCornerShape(20.dp))
                     } else Modifier
                 )
         ) {
@@ -121,7 +122,7 @@ private fun PinnedStationChip(
             Icon(
                 painter = painterResource(id = R.drawable.ic_star_filled),
                 contentDescription = null,
-                tint = Color(0xFFFF4081),
+                tint = RadioTheme.colors.primary,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(4.dp)

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/PinnedStationRow.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/PinnedStationRow.kt
@@ -1,8 +1,6 @@
 package io.github.agimaulana.radio.feature.stationlist.component
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -10,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -24,7 +21,6 @@ import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -34,7 +30,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.rememberAsyncImagePainter
 import io.github.agimaulana.radio.core.design.theme.PreviewTheme
 import io.github.agimaulana.radio.feature.stationlist.R
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
@@ -106,23 +101,20 @@ private fun PinnedStationChip(
         Box(
             modifier = Modifier
                 .size(72.dp)
-                .clip(RoundedCornerShape(20.dp))
-                .background(Color.White.copy(alpha = 0.1f))
                 .then(
                     if (station.isPlaying) {
                         Modifier.border(2.dp, Color(0xFFFF4081), RoundedCornerShape(20.dp))
                     } else Modifier
                 )
         ) {
-            Image(
-                painter = rememberAsyncImagePainter(
-                    model = station.imageUrl,
-                    placeholder = painterResource(id = R.drawable.station_default),
-                    error = painterResource(id = R.drawable.station_default)
-                ),
-                contentDescription = station.name,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize()
+            StationImage(
+                stationName = station.name,
+                imageUrl = station.imageUrl,
+                modifier = Modifier.align(Alignment.Center),
+                size = 72.dp,
+                cornerRadius = 20.dp,
+                placeholderSize = 36.dp,
+                imageContentScale = ContentScale.Crop,
             )
 
             // Star badge overlay

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationContextMenu.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationContextMenu.kt
@@ -1,0 +1,287 @@
+package io.github.agimaulana.radio.feature.stationlist.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil.compose.rememberAsyncImagePainter
+import io.github.agimaulana.radio.core.design.RadioTheme
+import io.github.agimaulana.radio.core.design.theme.PreviewTheme
+import io.github.agimaulana.radio.feature.stationlist.R
+import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.Action
+import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun StationContextMenu(
+    showMenu: Boolean,
+    station: Station?,
+    onDismiss: () -> Unit,
+    onAction: (Action) -> Unit,
+    useBottomSheet: Boolean = true
+) {
+    if (station == null || !showMenu) return
+    val containerColor = MaterialTheme.colorScheme.surface
+    val dividerColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+
+    if (useBottomSheet) {
+        ModalBottomSheet(
+            onDismissRequest = onDismiss,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = containerColor,
+            dragHandle = null
+        ) {
+            MenuContent(
+                station = station,
+                dividerColor = dividerColor,
+                onDismiss = onDismiss,
+                onAction = onAction
+            )
+        }
+    } else {
+        Dialog(
+            onDismissRequest = onDismiss,
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(24.dp),
+                    color = containerColor,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    MenuContent(
+                        station = station,
+                        dividerColor = dividerColor,
+                        onDismiss = onDismiss,
+                        onAction = onAction
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MenuContent(
+    station: Station,
+    dividerColor: Color,
+    onDismiss: () -> Unit,
+    onAction: (Action) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 16.dp)
+    ) {
+        Header(station)
+
+        HorizontalDivider(
+            modifier = Modifier.padding(vertical = 8.dp),
+            color = dividerColor
+        )
+
+        MenuItem(
+            text = stringResource(id = R.string.menu_play_now),
+            icon = painterResource(id = R.drawable.ic_play),
+            onClick = {
+                onAction(Action.Click(station))
+                onDismiss()
+            }
+        )
+
+        if (station.isPinned) {
+            MenuItem(
+                text = stringResource(id = R.string.menu_remove_pin),
+                icon = painterResource(id = R.drawable.ic_star_filled),
+                onClick = {
+                onAction(Action.UnpinStation(station.serverUuid))
+                onDismiss()
+                },
+                iconColor = RadioTheme.colors.primary
+            )
+        } else {
+            MenuItem(
+                text = stringResource(id = R.string.menu_pin_station),
+                icon = painterResource(id = R.drawable.ic_star_filled),
+                onClick = {
+                    onAction(Action.PinStation(station))
+                    onDismiss()
+                }
+            )
+        }
+
+        MenuItem(
+            text = stringResource(id = R.string.menu_share),
+            icon = painterResource(id = R.drawable.ic_share),
+            onClick = {
+                // TODO: Share action
+                onDismiss()
+            },
+            iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            textColor = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun Header(station: Station) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(
+                model = station.imageUrl,
+                placeholder = painterResource(id = R.drawable.station_default),
+                error = painterResource(id = R.drawable.station_default)
+            ),
+            contentDescription = null,
+            modifier = Modifier
+                .size(56.dp)
+                .clip(RoundedCornerShape(12.dp)),
+            contentScale = ContentScale.Crop
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column {
+            Text(
+                text = station.name,
+                style = MaterialTheme.typography.titleMedium.copy(
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp
+                )
+            )
+            Text(
+                text = station.genre,
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun MenuItem(
+    text: String,
+    icon: Painter,
+    onClick: () -> Unit,
+    iconColor: Color = RadioTheme.colors.primary,
+    textColor: Color = RadioTheme.colors.primary
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Start
+        ) {
+            Icon(
+                painter = icon,
+                contentDescription = null,
+                tint = iconColor,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(20.dp))
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    color = textColor,
+                    fontWeight = FontWeight.Medium
+                )
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun StationContextMenuPreview() {
+    PreviewTheme {
+        StationContextMenu(
+            showMenu = true,
+            station = Station(
+                serverUuid = "1",
+                name = "Most 105.8 FM Jakarta",
+                genre = "90s",
+                imageUrl = "",
+                streamUrl = "",
+                isBuffering = false,
+                isPlaying = false,
+                isPinned = false
+            ),
+            onDismiss = {},
+            onAction = {},
+            useBottomSheet = true
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun StationContextMenuDialogPreview() {
+    PreviewTheme {
+        StationContextMenu(
+            showMenu = true,
+            station = Station(
+                serverUuid = "1",
+                name = "Most 105.8 FM Jakarta",
+                genre = "90s",
+                imageUrl = "",
+                streamUrl = "",
+                isBuffering = false,
+                isPlaying = false,
+                isPinned = true
+            ),
+            onDismiss = {},
+            onAction = {},
+            useBottomSheet = false
+        )
+    }
+}

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationImage.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationImage.kt
@@ -1,0 +1,80 @@
+package io.github.agimaulana.radio.feature.stationlist.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImagePainter
+import coil.compose.rememberAsyncImagePainter
+import io.github.agimaulana.radio.core.design.RadioTheme
+import io.github.agimaulana.radio.feature.stationlist.R
+import timber.log.Timber
+
+@Composable
+internal fun StationImage(
+    stationName: String,
+    imageUrl: String,
+    modifier: Modifier = Modifier,
+    size: Dp,
+    cornerRadius: Dp = 8.dp,
+    placeholderSize: Dp,
+    imageContentScale: ContentScale = ContentScale.Fit,
+) {
+    val painter = rememberAsyncImagePainter(
+        model = imageUrl,
+        placeholder = painterResource(id = R.drawable.station_default),
+        error = painterResource(id = R.drawable.station_default),
+        onLoading = {
+            Timber.tag("StationImage").d("Loading image for %s: %s", stationName, imageUrl)
+        },
+        onSuccess = {
+            Timber.tag("StationImage").d("Image loaded for %s: %s", stationName, imageUrl)
+        },
+        onError = {
+            Timber.tag("StationImage").d("Error loading image for %s: %s", stationName, imageUrl)
+        }
+    )
+
+    when (painter.state) {
+        is AsyncImagePainter.State.Success -> {
+            Image(
+                modifier = modifier
+                    .clip(RoundedCornerShape(cornerRadius))
+                    .background(RadioTheme.colors.muted)
+                    .size(size),
+                painter = painter,
+                contentDescription = stationName,
+                contentScale = imageContentScale,
+            )
+        }
+
+        else -> {
+            Box(
+                modifier = modifier
+                    .clip(RoundedCornerShape(cornerRadius))
+                    .background(RadioTheme.colors.muted)
+                    .size(size)
+            ) {
+                Image(
+                    modifier = Modifier
+                        .size(placeholderSize)
+                        .align(Alignment.Center),
+                    painter = painter,
+                    contentDescription = stationName,
+                    colorFilter = ColorFilter.tint(RadioTheme.colors.mutedForeground),
+                    contentScale = ContentScale.Fit,
+                )
+            }
+        }
+    }
+}

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationTile.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationTile.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,8 +15,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.material3.MaterialTheme
@@ -42,11 +46,13 @@ import io.github.agimaulana.radio.feature.stationlist.R
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
 import timber.log.Timber
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun StationTile(
     station: Station,
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
+    onLongClick: () -> Unit = {},
 ) {
     val border = if (station.isPlaying) RadioTheme.colors.ring else RadioTheme.colors.border
     val background = if (station.isPlaying) {
@@ -72,7 +78,10 @@ internal fun StationTile(
             modifier = modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(16.dp))
-                .clickable(onClick = onClick)
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = onLongClick
+                )
                 .padding(vertical = 16.dp)
                 .padding(start = 16.dp, end = 48.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -81,6 +90,25 @@ internal fun StationTile(
                 station = station,
                 contentColor = contentColor,
             )
+        }
+
+        if (station.isPinned) {
+            Box(
+                modifier = Modifier
+                    .offset(x = 8.dp, y = (-8).dp)
+                    .align(Alignment.TopStart)
+                    .size(28.dp)
+                    .background(RadioTheme.colors.ring, CircleShape)
+                    .border(2.dp, MaterialTheme.colorScheme.surface, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                androidx.compose.material3.Icon(
+                    painter = painterResource(id = R.drawable.ic_star_filled),
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
         }
 
         AnimatedVisibility(
@@ -213,7 +241,8 @@ internal class StationPreviewProvider : PreviewParameterProvider<Station> {
                 imageUrl = "",
                 streamUrl = "",
                 isBuffering = false,
-                isPlaying = false
+                isPlaying = false,
+                isPinned = false
             ),
             Station(
                 serverUuid = "uuid",
@@ -222,7 +251,8 @@ internal class StationPreviewProvider : PreviewParameterProvider<Station> {
                 imageUrl = "",
                 streamUrl = "",
                 isBuffering = false,
-                isPlaying = true
+                isPlaying = true,
+                isPinned = true
             ),
         )
 

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationTile.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationTile.kt
@@ -2,13 +2,10 @@ package io.github.agimaulana.radio.feature.stationlist.component
 
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,7 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
@@ -28,23 +25,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImagePainter
-import coil.compose.rememberAsyncImagePainter
 import io.github.agimaulana.radio.core.design.RadioTheme
 import io.github.agimaulana.radio.core.design.theme.PreviewTheme
 import io.github.agimaulana.radio.feature.stationlist.R
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
-import timber.log.Timber
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -127,9 +118,11 @@ private fun RowScope.details(
     station: Station,
     contentColor: Color
 ) {
-    RadioImage(
+    StationImage(
         stationName = station.name,
         imageUrl = station.imageUrl,
+        size = 96.dp,
+        placeholderSize = 48.dp,
     )
 
     Column(
@@ -150,65 +143,6 @@ private fun RowScope.details(
         )
     }
 }
-
-@Composable
-private fun RadioImage(
-    stationName: String,
-    imageUrl: String,
-    modifier: Modifier = Modifier,
-    size: Dp = 96.dp,
-    placeholderSize: Dp = 48.dp
-) {
-    val painter = rememberAsyncImagePainter(
-        model = imageUrl,
-        placeholder = painterResource(id = R.drawable.station_default),
-        error = painterResource(id = R.drawable.station_default),
-        onLoading = {
-            Timber.tag("StationTile").d("Loading image for %s: %s", stationName, imageUrl)
-        },
-        onSuccess = {
-            Timber.tag("StationTile").d("Image loaded for %s: %s", stationName, imageUrl)
-        },
-        onError = {
-            Timber.tag("StationTile").d("Error loading image for %s: %s", stationName, imageUrl)
-        }
-    )
-    Box {
-        when (painter.state) {
-            is AsyncImagePainter.State.Success -> {
-                Image(
-                    modifier = modifier
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(RadioTheme.colors.muted)
-                        .size(size),
-                    painter = painter,
-                    contentDescription = stationName,
-                    contentScale = ContentScale.Fit,
-                )
-            }
-
-            else -> {
-                Box(
-                    modifier = modifier
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(RadioTheme.colors.muted)
-                        .size(size)
-                ) {
-                    Image(
-                        modifier = Modifier
-                            .size(placeholderSize)
-                            .align(Alignment.Center),
-                        painter = painter,
-                        contentDescription = stationName,
-                        colorFilter = ColorFilter.tint(RadioTheme.colors.mutedForeground),
-                        contentScale = ContentScale.Fit,
-                    )
-                }
-            }
-        }
-    }
-}
-
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, showBackground = true)
 @Composable

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationTile.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/StationTile.kt
@@ -54,7 +54,7 @@ internal fun StationTile(
 
     val contentColor = contentColorFor(background)
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(16.dp))
             .border(
@@ -66,7 +66,7 @@ internal fun StationTile(
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(16.dp))
                 .combinedClickable(

--- a/feature/stationlist/src/main/res/drawable/ic_star_filled.xml
+++ b/feature/stationlist/src/main/res/drawable/ic_star_filled.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2L9.19,8.63L2,9.24l5.46,4.73L5.82,21z" />
+</vector>

--- a/feature/stationlist/src/main/res/values/strings.xml
+++ b/feature/stationlist/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="menu_remove_pin">Remove from pinned</string>
     <string name="menu_share">Share</string>
     <string name="pinned_removed_message">Removed %s</string>
+    <string name="pinned_limit_reached_message">You can pin up to %1$d stations</string>
     <string name="undo">Undo</string>
     <string name="label_pinned">PINNED</string>
     <string name="label_all_stations">ALL STATIONS</string>

--- a/feature/stationlist/src/main/res/values/strings.xml
+++ b/feature/stationlist/src/main/res/values/strings.xml
@@ -10,4 +10,12 @@
     <string name="location_perm_revokable_desc">Change anytime in Settings</string>
     <string name="location_perm_allow_button">Allow Location Access</string>
     <string name="location_perm_not_now_button">Not now</string>
+    <string name="menu_play_now">Play now</string>
+    <string name="menu_pin_station">Pin station</string>
+    <string name="menu_remove_pin">Remove from pinned</string>
+    <string name="menu_share">Share</string>
+    <string name="pinned_removed_message">Removed %s</string>
+    <string name="undo">Undo</string>
+    <string name="label_pinned">PINNED</string>
+    <string name="label_all_stations">ALL STATIONS</string>
 </resources>

--- a/feature/stationlist/src/main/res/values/strings.xml
+++ b/feature/stationlist/src/main/res/values/strings.xml
@@ -18,4 +18,6 @@
     <string name="undo">Undo</string>
     <string name="label_pinned">PINNED</string>
     <string name="label_all_stations">ALL STATIONS</string>
+    <string name="pinned_station_row">PINNED</string>
+    <string name="all_stations_list">ALL STATIONS</string>
 </resources>

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
@@ -2,6 +2,7 @@ package io.github.agimaulana.radio.feature.stationlist
 
 import app.cash.turbine.turbineScope
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
+import io.github.agimaulana.radio.feature.stationlist.datafactories.newRadioStation
 import io.github.agimaulana.radio.feature.stationlist.datafactories.newUiStateStation
 import io.github.agimaulana.radio.feature.stationlist.location.LocationProvider
 import io.mockk.coEvery
@@ -204,6 +205,26 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
         viewModel.init(hasLocationPermission = false, shouldShowRationale = false)
         viewModel.onAction(StationListViewModel.Action.Play(station))
         verify { radioPlayerController.play() }
+    }
+
+    @Test
+    fun `when pin station then execute use case`() = runTest {
+        val station = newUiStateStation(withServerUuid = "uuid-1")
+        val domainStation = newRadioStation(withStationUuid = "uuid-1")
+        coEvery { getRadioStationUseCase.execute("uuid-1") } returns domainStation
+
+        viewModel.onAction(StationListViewModel.Action.PinStation(station))
+        runCurrent()
+
+        coVerify { pinStationUseCase.execute(domainStation) }
+    }
+
+    @Test
+    fun `when unpin station then execute use case`() = runTest {
+        viewModel.onAction(StationListViewModel.Action.UnpinStation("uuid-1"))
+        runCurrent()
+
+        coVerify { unpinStationUseCase.execute("uuid-1") }
     }
 
     @Test

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
@@ -19,8 +19,9 @@ import org.junit.Test
 class StationListViewModelTest : StationListViewModelTest__Fixtures() {
 
     @Test
-    fun `initial state should have isLoading true`() = runTest {
-        assertTrue(viewModel.uiState.value.isLoading)
+    fun `initial state should have pinned and stations loading true`() = runTest {
+        assertTrue(viewModel.uiState.value.isPinnedStationsLoading)
+        assertTrue(viewModel.uiState.value.isStationsLoading)
     }
 
     @Test
@@ -31,6 +32,8 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
 
             viewModel.init()
             runCurrent()
+
+            uiState.expectMostRecentItem()
 
             coVerify(exactly = 1) {
                 radioPlayerControllerFactory.get()
@@ -48,7 +51,7 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
             runCurrent()
 
             // Sheet should remain false (already granted)
-            assertFalse(uiState.awaitItem().showLocationPermissionSheet)
+            assertFalse(uiState.expectMostRecentItem().showLocationPermissionSheet)
         }
     }
 
@@ -63,7 +66,7 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
             runCurrent()
 
             // Sheet stays false (permanently denied)
-            assertFalse(uiState.awaitItem().showLocationPermissionSheet)
+            assertFalse(uiState.expectMostRecentItem().showLocationPermissionSheet)
         }
     }
 
@@ -134,7 +137,7 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
             // Third emission: fetch complete
             with(uiState.awaitItem()) {
                 assertEquals(1, currentPage)
-                assertFalse(isLoading)
+                assertFalse(isStationsLoading)
             }
 
             coVerify {
@@ -167,7 +170,7 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
             // Second emission: fetch complete
             with(uiState.awaitItem()) {
                 assertEquals(1, currentPage)
-                assertFalse(isLoading)
+                assertFalse(isStationsLoading)
             }
 
             coVerify {

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
@@ -1,6 +1,8 @@
 package io.github.agimaulana.radio.feature.stationlist
 
 import app.cash.turbine.turbineScope
+import app.cash.turbine.test
+import io.github.agimaulana.radio.domain.api.repository.PinnedStationLimitReachedException
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.feature.stationlist.datafactories.newRadioStation
 import io.github.agimaulana.radio.feature.stationlist.datafactories.newUiStateStation
@@ -220,6 +222,25 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
         runCurrent()
 
         coVerify { pinStationUseCase.execute(domainStation) }
+    }
+
+    @Test
+    fun `when pin station reaches limit then emit snackbar event`() = runTest {
+        val station = newUiStateStation(withServerUuid = "uuid-1")
+        val domainStation = newRadioStation(withStationUuid = "uuid-1")
+        coEvery { getRadioStationUseCase.execute("uuid-1") } returns domainStation
+        coEvery { pinStationUseCase.execute(domainStation) } throws PinnedStationLimitReachedException(maxPins = 8)
+
+        viewModel.uiEvent.test {
+            viewModel.onAction(StationListViewModel.Action.PinStation(station))
+            runCurrent()
+
+            assertEquals(
+                StationListViewModel.UiEvent.ShowPinnedLimitReached(maxPins = 8),
+                awaitItem()
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__Fixtures.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__Fixtures.kt
@@ -8,8 +8,11 @@ import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
+import io.github.agimaulana.radio.domain.api.usecase.PinStationUseCase
+import io.github.agimaulana.radio.domain.api.usecase.UnpinStationUseCase
 import io.github.agimaulana.radio.feature.stationlist.datafactories.newRadioStation
 import io.github.agimaulana.radio.feature.stationlist.datafactories.newUiStateStation
 import io.github.agimaulana.radio.feature.stationlist.location.LocationProvider
@@ -20,6 +23,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.mockk
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.receiveAsFlow
 import org.junit.Before
 import org.junit.Rule
@@ -35,6 +39,15 @@ abstract class StationListViewModelTest__Fixtures {
 
     @RelaxedMockK
     protected lateinit var getRadioStationUseCase: GetRadioStationUseCase
+
+    @RelaxedMockK
+    protected lateinit var getPinnedStationsUseCase: GetPinnedStationsUseCase
+
+    @RelaxedMockK
+    protected lateinit var pinStationUseCase: PinStationUseCase
+
+    @RelaxedMockK
+    protected lateinit var unpinStationUseCase: UnpinStationUseCase
 
     @RelaxedMockK
     protected lateinit var radioPlayerController: RadioPlayerController
@@ -80,9 +93,16 @@ abstract class StationListViewModelTest__Fixtures {
         coEvery {
             getRadioStationsUseCase.execute(page = 1, searchName = null, location = null)
         } returns emptyList()
+        every {
+            getPinnedStationsUseCase.execute()
+        } returns flowOf(emptyList())
+
         viewModel = StationListViewModel(
             getRadioStationsUseCase = getRadioStationsUseCase,
             getRadioStationUseCase = getRadioStationUseCase,
+            getPinnedStationsUseCase = getPinnedStationsUseCase,
+            pinStationUseCase = pinStationUseCase,
+            unpinStationUseCase = unpinStationUseCase,
             radioPlayerControllerFactory = radioPlayerControllerFactory,
             stationListTracker = stationListTracker,
             locationProvider = locationProvider,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ swiperefreshlayout = "1.1.0"
 androidxPalette = "1.0.0"
 androidxStartup = "1.2.0"
 playServicesLocation = "21.3.0"
+androidxDataStore = "1.1.7"
 
 # only for tests
 turbine = "1.2.1"
@@ -117,6 +118,7 @@ androidx-palette = { group = "androidx.palette", name = "palette", version.ref =
 androidx-startup = { group = "androidx.startup", name = "startup-runtime", version.ref = "androidxStartup" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 androidx-compose-animation-graphics = { group = "androidx.compose.animation", name = "animation-graphics", version.ref = "compose" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDataStore" }
 
 # only for tests
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }

--- a/infrastructure/build.gradle.kts
+++ b/infrastructure/build.gradle.kts
@@ -8,6 +8,7 @@ android {
 }
 
 dependencies {
+    implementation(libs.androidx.datastore.preferences)
     implementation(libs.moshi)
     ksp(libs.moshi.codegen)
     implementation(project(":core:common"))

--- a/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/di/RepositoryModule.kt
+++ b/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/di/RepositoryModule.kt
@@ -3,14 +3,19 @@ package io.github.agimaulana.radio.infrastructure.di
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.components.SingletonComponent
+import io.github.agimaulana.radio.domain.api.repository.PinnedStationRepository
 import io.github.agimaulana.radio.domain.api.repository.RadioStationRepository
+import io.github.agimaulana.radio.infrastructure.repository.PinnedStationRepositoryImpl
 import io.github.agimaulana.radio.infrastructure.repository.RadioStationRepositoryImpl
 
 @Module
-@InstallIn(ViewModelComponent::class)
+@InstallIn(SingletonComponent::class)
 interface RepositoryModule {
 
     @Binds
     fun bindRadioStationRepository(impl: RadioStationRepositoryImpl): RadioStationRepository
+
+    @Binds
+    fun bindPinnedStationRepository(impl: PinnedStationRepositoryImpl): PinnedStationRepository
 }

--- a/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/repository/PinnedStationRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/repository/PinnedStationRepositoryImpl.kt
@@ -1,69 +1,83 @@
 package io.github.agimaulana.radio.infrastructure.repository
 
 import android.content.Context
-import android.content.SharedPreferences
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.PinnedStationRepository
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private val Context.pinnedStationsDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = PinnedStationRepositoryImpl.DATA_STORE_NAME,
+    produceMigrations = { context ->
+        listOf(SharedPreferencesMigration(context, PinnedStationRepositoryImpl.PREFS_NAME))
+    }
+)
 
 @Singleton
 class PinnedStationRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val moshi: Moshi
+    moshi: Moshi
 ) : PinnedStationRepository {
-
-    private val sharedPreferences: SharedPreferences =
-        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    private val dataStore = context.pinnedStationsDataStore
 
     private val adapter = moshi.adapter<List<RadioStation>>(
         Types.newParameterizedType(List::class.java, RadioStation::class.java)
     )
 
-    override fun getPinnedStations(): Flow<List<RadioStation>> = callbackFlow {
-        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            if (key == KEY_PINNED_STATIONS) {
-                trySend(getPinnedStationsFromPrefs())
+    override fun getPinnedStations(): Flow<List<RadioStation>> {
+        return dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
             }
-        }
-        sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
-        trySend(getPinnedStationsFromPrefs())
-        awaitClose {
-            sharedPreferences.unregisterOnSharedPreferenceChangeListener(listener)
-        }
+            .map { preferences ->
+                decodePinnedStations(preferences[KEY_PINNED_STATIONS])
+            }
     }
 
     override suspend fun pinStation(station: RadioStation) {
-        val current = getPinnedStationsFromPrefs().toMutableList()
-        if (current.none { it.stationUuid == station.stationUuid }) {
-            if (current.size >= MAX_PINS) {
-                return // Cap at 8
+        dataStore.edit { preferences ->
+            val current = decodePinnedStations(preferences[KEY_PINNED_STATIONS]).toMutableList()
+            if (current.none { it.stationUuid == station.stationUuid } && current.size < MAX_PINS) {
+                current.add(station)
+                preferences[KEY_PINNED_STATIONS] = adapter.toJson(current)
             }
-            current.add(station)
-            savePinnedStationsToPrefs(current)
         }
     }
 
     override suspend fun unpinStation(stationUuid: String) {
-        val current = getPinnedStationsFromPrefs().toMutableList()
-        if (current.removeIf { it.stationUuid == stationUuid }) {
-            savePinnedStationsToPrefs(current)
+        dataStore.edit { preferences ->
+            val current = decodePinnedStations(preferences[KEY_PINNED_STATIONS]).toMutableList()
+            if (current.removeIf { it.stationUuid == stationUuid }) {
+                preferences[KEY_PINNED_STATIONS] = adapter.toJson(current)
+            }
         }
     }
 
     override suspend fun isPinned(stationUuid: String): Boolean {
-        return getPinnedStationsFromPrefs().any { it.stationUuid == stationUuid }
+        return getPinnedStations().first().any { it.stationUuid == stationUuid }
     }
 
-    private fun getPinnedStationsFromPrefs(): List<RadioStation> {
-        val json = sharedPreferences.getString(KEY_PINNED_STATIONS, null) ?: return emptyList()
+    private fun decodePinnedStations(json: String?): List<RadioStation> {
+        if (json.isNullOrEmpty()) return emptyList()
         return try {
             adapter.fromJson(json) ?: emptyList()
         } catch (e: Exception) {
@@ -71,14 +85,10 @@ class PinnedStationRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun savePinnedStationsToPrefs(stations: List<RadioStation>) {
-        val json = adapter.toJson(stations)
-        sharedPreferences.edit().putString(KEY_PINNED_STATIONS, json).apply()
-    }
-
     companion object {
-        private const val PREFS_NAME = "pinned_stations_prefs"
-        private const val KEY_PINNED_STATIONS = "pinned_stations"
+        const val PREFS_NAME = "pinned_stations_prefs"
+        const val DATA_STORE_NAME = "pinned_stations"
+        val KEY_PINNED_STATIONS = stringPreferencesKey("pinned_stations")
         private const val MAX_PINS = 8
     }
 }

--- a/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/repository/PinnedStationRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/repository/PinnedStationRepositoryImpl.kt
@@ -1,0 +1,84 @@
+package io.github.agimaulana.radio.infrastructure.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.repository.PinnedStationRepository
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.onStart
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PinnedStationRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val moshi: Moshi
+) : PinnedStationRepository {
+
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private val adapter = moshi.adapter<List<RadioStation>>(
+        Types.newParameterizedType(List::class.java, RadioStation::class.java)
+    )
+
+    override fun getPinnedStations(): Flow<List<RadioStation>> = callbackFlow {
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == KEY_PINNED_STATIONS) {
+                trySend(getPinnedStationsFromPrefs())
+            }
+        }
+        sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
+        trySend(getPinnedStationsFromPrefs())
+        awaitClose {
+            sharedPreferences.unregisterOnSharedPreferenceChangeListener(listener)
+        }
+    }
+
+    override suspend fun pinStation(station: RadioStation) {
+        val current = getPinnedStationsFromPrefs().toMutableList()
+        if (current.none { it.stationUuid == station.stationUuid }) {
+            if (current.size >= MAX_PINS) {
+                return // Cap at 8
+            }
+            current.add(station)
+            savePinnedStationsToPrefs(current)
+        }
+    }
+
+    override suspend fun unpinStation(stationUuid: String) {
+        val current = getPinnedStationsFromPrefs().toMutableList()
+        if (current.removeIf { it.stationUuid == stationUuid }) {
+            savePinnedStationsToPrefs(current)
+        }
+    }
+
+    override suspend fun isPinned(stationUuid: String): Boolean {
+        return getPinnedStationsFromPrefs().any { it.stationUuid == stationUuid }
+    }
+
+    private fun getPinnedStationsFromPrefs(): List<RadioStation> {
+        val json = sharedPreferences.getString(KEY_PINNED_STATIONS, null) ?: return emptyList()
+        return try {
+            adapter.fromJson(json) ?: emptyList()
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun savePinnedStationsToPrefs(stations: List<RadioStation>) {
+        val json = adapter.toJson(stations)
+        sharedPreferences.edit().putString(KEY_PINNED_STATIONS, json).apply()
+    }
+
+    companion object {
+        private const val PREFS_NAME = "pinned_stations_prefs"
+        private const val KEY_PINNED_STATIONS = "pinned_stations"
+        private const val MAX_PINS = 8
+    }
+}

--- a/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/repository/PinnedStationRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/repository/PinnedStationRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.repository.PinnedStationLimitReachedException
 import io.github.agimaulana.radio.domain.api.repository.PinnedStationRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -56,10 +57,13 @@ class PinnedStationRepositoryImpl @Inject constructor(
     override suspend fun pinStation(station: RadioStation) {
         dataStore.edit { preferences ->
             val current = decodePinnedStations(preferences[KEY_PINNED_STATIONS]).toMutableList()
-            if (current.none { it.stationUuid == station.stationUuid } && current.size < MAX_PINS) {
-                current.add(station)
-                preferences[KEY_PINNED_STATIONS] = adapter.toJson(current)
+            val isAlreadyPinned = current.any { it.stationUuid == station.stationUuid }
+            if (isAlreadyPinned) return@edit
+            if (current.size >= MAX_PINS) {
+                throw PinnedStationLimitReachedException(MAX_PINS)
             }
+            current.add(station)
+            preferences[KEY_PINNED_STATIONS] = adapter.toJson(current)
         }
     }
 


### PR DESCRIPTION
## Summary
- add pinned station persistence and station list actions
- add station context menu, pinned row, and toolbar/list layout updates
- migrate pinned station storage to DataStore

## Linked issue
- Related to #11

## Verification
- `./gradlew :infrastructure:compileDevDebugKotlin :feature:stationlist:compileDevDebugKotlin --console=plain 2>&1 | grep -E '(e:|w:|error:|warning:|FAILED|BUILD|\\.kt:)'`
- `android screen capture` for runtime layout checks