### PR TITLE
test: add integration tests for restoreFromPlayer process death

### DIFF
--- a/.agents/skills/respond-to-pr-reviews/scripts/fetch_unresolved_reviews.sh
+++ b/.agents/skills/respond-to-pr-reviews/scripts/fetch_unresolved_reviews.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+OWNER=${1?Usage: $0 <owner> <repo> <pr_number>}
+REPO=${2?Usage: $0 <owner> <repo> <pr_number>}
+PR_NUMBER=${3?Usage: $0 <owner> <repo> <pr_number>}
+
+gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER" -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            path
+            line
+            originalLine
+            comments(first: 100) {
+              nodes {
+                databaseId
+                author { login }
+                body
+              }
+            }
+          }
+        }
+      }
+    }
+  }' --jq '[
+    .data.repository.pullRequest.reviewThreads.nodes[]
+    | select(.isResolved == false)
+    | "ThreadID: \(.id)\nPath: \(.path):\(.line // .originalLine // "unknown")\nComments:\n" + (.comments.nodes | map("  [comment_id=\(.databaseId)] [\(.author.login)]: \(.body | .[0:500])") | join("\n")) + "\n---"
+  ] | if length == 0 then "No unresolved reviews" else join("\n") end'

--- a/core/radioplayer/build.gradle.kts
+++ b/core/radioplayer/build.gradle.kts
@@ -15,4 +15,10 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+
+    androidTestImplementation(libs.androidx.media3.session)
+    androidTestImplementation(libs.androidx.media3.exoplayer)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 }

--- a/core/radioplayer/build.gradle.kts
+++ b/core/radioplayer/build.gradle.kts
@@ -10,4 +10,9 @@ dependencies {
     implementation(libs.androidx.media3.session)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.exoplayer.hls)
+
+    testImplementation(libs.robolectric)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItem.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItem.kt
@@ -17,16 +17,29 @@ data class RadioMediaItem(
     )
 }
 
-internal fun RadioMediaItem.toMediaItem(): MediaItem {
+internal fun RadioMediaItem.toMediaItem(
+    contextType: String? = null,
+    contextQuery: String? = null,
+    page: Int? = null
+): MediaItem {
+    val metadataBuilder = MediaMetadata.Builder()
+        .setTitle(radioMetadata.stationName)
+        .setSubtitle(radioMetadata.genre)
+        .setArtworkUri(radioMetadata.imageUrl.toUri())
+
+    // Attach minimal playback context so the service can restore context after process death
+    val extras = android.os.Bundle()
+    contextType?.let { extras.putString("playback_context_type", it) }
+    contextQuery?.let { extras.putString("playback_context_query", it) }
+    page?.let { extras.putInt("playback_context_page", it) }
+
+    if (!extras.isEmpty) {
+        metadataBuilder.setExtras(extras)
+    }
+
     return MediaItem.Builder()
         .setMediaId(mediaId)
         .setUri(streamUrl)
-        .setMediaMetadata(
-            MediaMetadata.Builder()
-                .setTitle(radioMetadata.stationName)
-                .setSubtitle(radioMetadata.genre)
-                .setArtworkUri(radioMetadata.imageUrl.toUri())
-                .build()
-        )
+        .setMediaMetadata(metadataBuilder.build())
         .build()
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioPlayerController.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioPlayerController.kt
@@ -6,7 +6,19 @@ interface RadioPlayerController {
     val event: Flow<PlaybackEvent>
     val currentMediaId: String?
     val isPlaying: Boolean
+
+    // Single-item compatibility
     fun setMediaItem(radioMediaItem: RadioMediaItem)
+
+    // Playlist APIs - Use startPlayback for proper PlaybackManager sync
+    fun startPlayback(items: List<RadioMediaItem>, startIndex: Int = 0, contextType: String? = null, contextQuery: String? = null)
+    fun setMediaItems(items: List<RadioMediaItem>, startIndex: Int = 0, contextType: String? = null, contextQuery: String? = null)
+    fun addMediaItems(items: List<RadioMediaItem>, contextType: String? = null, contextQuery: String? = null)
+    fun addMediaItems(index: Int, items: List<RadioMediaItem>, contextType: String? = null, contextQuery: String? = null)
+
+    val mediaItemCount: Int
+    val currentMediaItemIndex: Int
+
     fun prepare()
     fun play()
     fun pause()

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
@@ -14,20 +14,56 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
+import io.github.agimaulana.radio.core.radioplayer.internal.PlaybackManager
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioMediaSessionCallback
+import io.github.agimaulana.radio.core.radioplayer.internal.ServiceResolver
 
 @OptIn(UnstableApi::class)
 class RadioService : MediaSessionService() {
     private var mediaSession: MediaSession? = null
+    private var playbackManager: PlaybackManager? = null
 
     override fun onCreate() {
         super.onCreate()
         val player = createPlayer()
+        // Initialize PlaybackManager with a no-op fetcher for now. The fetcher will be injected/wired later
+        // Wire a fetcher that calls the domain use-case via a lazy resolver to avoid tight coupling in module boundaries.
+        playbackManager = PlaybackManager(player) { page, query ->
+            val resolver = ServiceResolver.resolveGetRadioStationsResolver()
+            if (resolver != null) {
+                try {
+                    resolver.invoke(page, query)
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) {
+                        throw e
+                    }
+                    emptyList()
+                }
+            } else emptyList()
+        }
+
+        // Register PlaybackManager.startPlayback with ServiceResolver so controller can call it
+        playbackManager?.let { manager ->
+            ServiceResolver.registerPlaybackStartCallback { items, startIndex, contextType, contextQuery ->
+                manager.startPlayback(
+                    items,
+                    startIndex,
+                    PlaybackManager.PlaybackContext(
+                        type = if (contextType == "SEARCH") PlaybackManager.PlaybackContext.Type.SEARCH else PlaybackManager.PlaybackContext.Type.DEFAULT,
+                        query = contextQuery
+                    )
+                )
+            }
+        }
+
         mediaSession = MediaSession.Builder(this, player)
             .setSessionActivity(createPendingMainActivityIntent())
             .setCallback(RadioMediaSessionCallback())
             .build()
         setMediaNotificationProvider(DefaultMediaNotificationProvider.Builder(this).build())
+
+        // Attempt to restore playback context from player playlist (if any persisted metadata exists)
+        playbackManager?.restoreFromPlayer()
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
@@ -47,6 +83,7 @@ class RadioService : MediaSessionService() {
             release()
             mediaSession = null
         }
+        playbackManager?.release()
         super.onDestroy()
     }
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManager.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManager.kt
@@ -28,15 +28,20 @@ internal class PlaybackManager(
     private val scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
 
     private val loadedItems = mutableListOf<RadioMediaItem>()
-    private val loadedIds = mutableSetOf<String>()
 
-    private var nextPage: Int = 1
     private var isFetchingNextPage: Boolean = false
 
-    private var playbackContext: PlaybackContext = PlaybackContext(
+    private var _playbackContext: PlaybackContext = PlaybackContext(
         type = PlaybackContext.Type.DEFAULT,
         query = null
     )
+    internal val playbackContext: PlaybackContext get() = _playbackContext
+
+    private var _loadedIds: MutableSet<String> = mutableSetOf()
+    internal val loadedIds: Set<String> get() = _loadedIds
+
+    internal var nextPage: Int = 1
+        private set
 
     private val playerListener = object : androidx.media3.common.Player.Listener {
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -63,14 +68,14 @@ internal class PlaybackManager(
         scope.launch {
             // Reset state
             loadedItems.clear()
-            loadedIds.clear()
+            _loadedIds.clear()
 
             loadedItems.addAll(items)
-            loadedIds.addAll(items.map { it.mediaId })
+            _loadedIds.addAll(items.map { it.mediaId })
 
             // Calculate starting page based on items size to avoid re-fetching initial pages
             nextPage = (items.size / PAGE_SIZE) + 1
-            playbackContext = context
+            _playbackContext = context
 
             val mediaItems = items.map {
                 it.toMediaItem(
@@ -87,16 +92,16 @@ internal class PlaybackManager(
 
     fun addMediaItems(items: List<RadioMediaItem>) {
         scope.launch {
-            val filtered = items.filterNot { loadedIds.contains(it.mediaId) }
+            val filtered = items.filterNot { _loadedIds.contains(it.mediaId) }
             if (filtered.isEmpty()) return@launch
 
             loadedItems.addAll(filtered)
-            loadedIds.addAll(filtered.map { it.mediaId })
+            _loadedIds.addAll(filtered.map { it.mediaId })
 
             val mediaItems = filtered.map {
                 it.toMediaItem(
-                    contextType = playbackContext.type.name,
-                    contextQuery = playbackContext.query,
+                    contextType = _playbackContext.type.name,
+                    contextQuery = _playbackContext.query,
                     page = null
                 )
             }
@@ -106,16 +111,16 @@ internal class PlaybackManager(
 
     fun addMediaItems(index: Int, items: List<RadioMediaItem>) {
         scope.launch {
-            val filtered = items.filterNot { loadedIds.contains(it.mediaId) }
+            val filtered = items.filterNot { _loadedIds.contains(it.mediaId) }
             if (filtered.isEmpty()) return@launch
 
             loadedItems.addAll(index, filtered)
-            loadedIds.addAll(filtered.map { it.mediaId })
+            _loadedIds.addAll(filtered.map { it.mediaId })
 
             val mediaItems = filtered.map {
                 it.toMediaItem(
-                    contextType = playbackContext.type.name,
-                    contextQuery = playbackContext.query,
+                    contextType = _playbackContext.type.name,
+                    contextQuery = _playbackContext.query,
                     page = null
                 )
             }
@@ -128,7 +133,7 @@ internal class PlaybackManager(
         val isAtEnd = player.currentMediaItemIndex == player.mediaItemCount - 1
         if (!isAtEnd) return
         if (isFetchingNextPage) return
-        if (playbackContext.type == PlaybackContext.Type.PINNED) return
+        if (_playbackContext.type == PlaybackContext.Type.PINNED) return
 
         scope.launch {
             fetchNextPage()
@@ -139,17 +144,17 @@ internal class PlaybackManager(
         if (isFetchingNextPage) return
         isFetchingNextPage = true
         try {
-            val newItems = fetcher(nextPage, playbackContext.query)
+            val newItems = fetcher(nextPage, _playbackContext.query)
             if (newItems.isNotEmpty()) {
-                val filtered = newItems.filterNot { loadedIds.contains(it.mediaId) }
+                val filtered = newItems.filterNot { _loadedIds.contains(it.mediaId) }
                 if (filtered.isNotEmpty()) {
                     // append
                     loadedItems.addAll(filtered)
-                    loadedIds.addAll(filtered.map { it.mediaId })
+                    _loadedIds.addAll(filtered.map { it.mediaId })
                     val mediaItems = filtered.map {
                         it.toMediaItem(
-                            contextType = playbackContext.type.name,
-                            contextQuery = playbackContext.query,
+                            contextType = _playbackContext.type.name,
+                            contextQuery = _playbackContext.query,
                             page = nextPage
                         )
                     }
@@ -173,7 +178,7 @@ internal class PlaybackManager(
         val extras = current.mediaMetadata.extras
         val typeName = extras?.getString("playback_context_type") ?: PlaybackContext.Type.DEFAULT.name
         val query = extras?.getString("playback_context_query")
-        playbackContext = try {
+        _playbackContext = try {
             PlaybackContext(PlaybackContext.Type.valueOf(typeName), query)
         } catch (e: Exception) {
             Timber.i(e)
@@ -181,9 +186,9 @@ internal class PlaybackManager(
         }
 
         // Restore loadedIds from current player items to avoid duplicates during pagination
-        loadedIds.clear()
+        _loadedIds.clear()
         repeat(player.mediaItemCount) { index ->
-            player.getMediaItemAt(index).mediaId?.let { loadedIds.add(it) }
+            player.getMediaItemAt(index).mediaId?.let { _loadedIds.add(it) }
         }
 
         // Estimate next page from current playlist size

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManager.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManager.kt
@@ -1,0 +1,197 @@
+package io.github.agimaulana.radio.core.radioplayer.internal
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
+import io.github.agimaulana.radio.core.radioplayer.toMediaItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * PlaybackManager owns the playback queue and pagination triggers.
+ * It is intentionally lightweight and accepts an optional fetcher lambda
+ * to request next-page items when the player reaches the end.
+ */
+internal class PlaybackManager(
+    private val player: Player,
+    private val fetcher: suspend (
+        nextPage: Int,
+        query: String?
+    ) -> List<RadioMediaItem> = { _: Int, _: String? -> emptyList() }
+) {
+
+    private val scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
+
+    private val loadedItems = mutableListOf<RadioMediaItem>()
+    private val loadedIds = mutableSetOf<String>()
+
+    private var nextPage: Int = 1
+    private var isFetchingNextPage: Boolean = false
+
+    private var playbackContext: PlaybackContext = PlaybackContext(
+        type = PlaybackContext.Type.DEFAULT,
+        query = null
+    )
+
+    private val playerListener = object : androidx.media3.common.Player.Listener {
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            maybeFetchNext()
+        }
+    }
+
+    init {
+        player.addListener(playerListener)
+    }
+
+    data class PlaybackContext(
+        val type: Type,
+        val query: String? = null,
+    ) {
+        enum class Type { DEFAULT, SEARCH, PINNED }
+    }
+
+    fun startPlayback(
+        items: List<RadioMediaItem>,
+        startIndex: Int = 0,
+        context: PlaybackContext = PlaybackContext(PlaybackContext.Type.DEFAULT, null)
+    ) {
+        scope.launch {
+            // Reset state
+            loadedItems.clear()
+            loadedIds.clear()
+
+            loadedItems.addAll(items)
+            loadedIds.addAll(items.map { it.mediaId })
+
+            // Calculate starting page based on items size to avoid re-fetching initial pages
+            nextPage = (items.size / PAGE_SIZE) + 1
+            playbackContext = context
+
+            val mediaItems = items.map {
+                it.toMediaItem(
+                    contextType = context.type.name,
+                    contextQuery = context.query,
+                    page = null
+                )
+            }
+            player.setMediaItems(mediaItems, startIndex, 0L)
+            player.prepare()
+            player.play()
+        }
+    }
+
+    fun addMediaItems(items: List<RadioMediaItem>) {
+        scope.launch {
+            val filtered = items.filterNot { loadedIds.contains(it.mediaId) }
+            if (filtered.isEmpty()) return@launch
+
+            loadedItems.addAll(filtered)
+            loadedIds.addAll(filtered.map { it.mediaId })
+
+            val mediaItems = filtered.map {
+                it.toMediaItem(
+                    contextType = playbackContext.type.name,
+                    contextQuery = playbackContext.query,
+                    page = null
+                )
+            }
+            player.addMediaItems(mediaItems)
+        }
+    }
+
+    fun addMediaItems(index: Int, items: List<RadioMediaItem>) {
+        scope.launch {
+            val filtered = items.filterNot { loadedIds.contains(it.mediaId) }
+            if (filtered.isEmpty()) return@launch
+
+            loadedItems.addAll(index, filtered)
+            loadedIds.addAll(filtered.map { it.mediaId })
+
+            val mediaItems = filtered.map {
+                it.toMediaItem(
+                    contextType = playbackContext.type.name,
+                    contextQuery = playbackContext.query,
+                    page = null
+                )
+            }
+            player.addMediaItems(index, mediaItems)
+        }
+    }
+
+    private fun maybeFetchNext() {
+        // Only attempt when at the last index, not already fetching, and not in PINNED context
+        val isAtEnd = player.currentMediaItemIndex == player.mediaItemCount - 1
+        if (!isAtEnd) return
+        if (isFetchingNextPage) return
+        if (playbackContext.type == PlaybackContext.Type.PINNED) return
+
+        scope.launch {
+            fetchNextPage()
+        }
+    }
+
+    suspend fun fetchNextPage() {
+        if (isFetchingNextPage) return
+        isFetchingNextPage = true
+        try {
+            val newItems = fetcher(nextPage, playbackContext.query)
+            if (newItems.isNotEmpty()) {
+                val filtered = newItems.filterNot { loadedIds.contains(it.mediaId) }
+                if (filtered.isNotEmpty()) {
+                    // append
+                    loadedItems.addAll(filtered)
+                    loadedIds.addAll(filtered.map { it.mediaId })
+                    val mediaItems = filtered.map {
+                        it.toMediaItem(
+                            contextType = playbackContext.type.name,
+                            contextQuery = playbackContext.query,
+                            page = nextPage
+                        )
+                    }
+                    player.addMediaItems(mediaItems)
+                }
+                nextPage++
+            }
+        } finally {
+            isFetchingNextPage = false
+        }
+    }
+
+    fun release() {
+        player.removeListener(playerListener)
+        scope.cancel()
+    }
+
+    // Restore minimal playback context from player's current media item metadata.
+    fun restoreFromPlayer() {
+        val current = player.currentMediaItem ?: return
+        val extras = current.mediaMetadata.extras
+        val typeName = extras?.getString("playback_context_type") ?: PlaybackContext.Type.DEFAULT.name
+        val query = extras?.getString("playback_context_query")
+        playbackContext = try {
+            PlaybackContext(PlaybackContext.Type.valueOf(typeName), query)
+        } catch (e: Exception) {
+            Timber.i(e)
+            PlaybackContext(PlaybackContext.Type.DEFAULT, null)
+        }
+
+        // Restore loadedIds from current player items to avoid duplicates during pagination
+        loadedIds.clear()
+        repeat(player.mediaItemCount) { index ->
+            player.getMediaItemAt(index).mediaId?.let { loadedIds.add(it) }
+        }
+
+        // Estimate next page from current playlist size
+        val itemCount = player.mediaItemCount
+        nextPage = (itemCount / PAGE_SIZE) + 1
+    }
+
+    companion object {
+        private const val PAGE_SIZE = 10
+    }
+}

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioMediaSessionCallback.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioMediaSessionCallback.kt
@@ -14,10 +14,10 @@ internal class RadioMediaSessionCallback : MediaSession.Callback {
 
         @OptIn(UnstableApi::class)
         val customPlayerCommands = connectionResult.availablePlayerCommands.buildUpon()
-            .remove(Player.COMMAND_SEEK_TO_NEXT)
-            .remove(Player.COMMAND_SEEK_TO_PREVIOUS)
-            .remove(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
-            .remove(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+            .add(Player.COMMAND_SEEK_TO_NEXT)
+            .add(Player.COMMAND_SEEK_TO_PREVIOUS)
+            .add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+            .add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
             .build()
 
         return MediaSession.ConnectionResult.accept(

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImpl.kt
@@ -6,7 +6,9 @@ import io.github.agimaulana.radio.core.radioplayer.PlaybackState
 import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.toMediaItem
+import io.github.agimaulana.radio.core.radioplayer.internal.ServiceResolver.resolvePlaybackStartCallback
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
 
 internal class RadioPlayerControllerImpl(
     private val mediaController: MediaController,
@@ -23,9 +25,46 @@ internal class RadioPlayerControllerImpl(
     override val isPlaying: Boolean
         get() = mediaController.isPlaying
 
+    // Single-item compatibility
     override fun setMediaItem(radioMediaItem: RadioMediaItem) {
         mediaController.setMediaItem(radioMediaItem.toMediaItem())
     }
+
+    // Playlist APIs - Route startPlayback through PlaybackManager for proper state sync
+    override fun startPlayback(items: List<RadioMediaItem>, startIndex: Int, contextType: String?, contextQuery: String?) {
+        val callback = resolvePlaybackStartCallback()
+        if (callback != null) {
+            runBlocking {
+                callback(items, startIndex, contextType, contextQuery)
+            }
+        } else {
+            // Fallback: direct setMediaItems if PlaybackManager not available
+            setMediaItems(items, startIndex, contextType, contextQuery)
+            prepare()
+            play()
+        }
+    }
+
+    override fun setMediaItems(items: List<RadioMediaItem>, startIndex: Int, contextType: String?, contextQuery: String?) {
+        val mediaItems = items.map { it.toMediaItem(contextType, contextQuery, null) }
+        mediaController.setMediaItems(mediaItems, startIndex, 0L)
+    }
+
+    override fun addMediaItems(items: List<RadioMediaItem>, contextType: String?, contextQuery: String?) {
+        val mediaItems = items.map { it.toMediaItem(contextType, contextQuery, null) }
+        mediaController.addMediaItems(mediaItems)
+    }
+
+    override fun addMediaItems(index: Int, items: List<RadioMediaItem>, contextType: String?, contextQuery: String?) {
+        val mediaItems = items.map { it.toMediaItem(contextType, contextQuery, null) }
+        mediaController.addMediaItems(index, mediaItems)
+    }
+
+    override val mediaItemCount: Int
+        get() = mediaController.mediaItemCount
+
+    override val currentMediaItemIndex: Int
+        get() = mediaController.currentMediaItemIndex
 
     override fun prepare() {
         mediaController.prepare()

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/ServiceResolver.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/ServiceResolver.kt
@@ -1,0 +1,37 @@
+package io.github.agimaulana.radio.core.radioplayer.internal
+
+import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
+
+/**
+ * Small resolver to avoid importing domain types into the core module.
+ * Other modules can register a lambda that fetches domain stations and maps to RadioMediaItem.
+ */
+object ServiceResolver {
+    @Volatile
+    private var resolver: (suspend (page: Int, query: String?) -> List<RadioMediaItem>)? = null
+
+    @Volatile
+    private var playbackStartCallback: (suspend (items: List<RadioMediaItem>, startIndex: Int, contextType: String?, contextQuery: String?) -> Unit)? = null
+
+    fun registerGetRadioStationsResolver(
+        r: suspend (page: Int, query: String?) -> List<RadioMediaItem>
+    ) {
+        resolver = r
+    }
+
+    fun clearGetRadioStationsResolver() {
+        resolver = null
+    }
+
+    fun resolveGetRadioStationsResolver():
+        (suspend (page: Int, query: String?) -> List<RadioMediaItem>)? = resolver
+
+    fun registerPlaybackStartCallback(
+        callback: suspend (items: List<RadioMediaItem>, startIndex: Int, contextType: String?, contextQuery: String?) -> Unit
+    ) {
+        playbackStartCallback = callback
+    }
+
+    fun resolvePlaybackStartCallback():
+        (suspend (items: List<RadioMediaItem>, startIndex: Int, contextType: String?, contextQuery: String?) -> Unit)? = playbackStartCallback
+}

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItemTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItemTest.kt
@@ -1,0 +1,31 @@
+package io.github.agimaulana.radio.core.radioplayer
+
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RadioMediaItemTest {
+
+    @Test
+    fun toMediaItem_attachesPlaybackContextExtras() {
+        val radio = RadioMediaItem(
+            mediaId = "id1",
+            streamUrl = "https://example.com/stream",
+            radioMetadata = RadioMediaItem.RadioMetadata(
+                stationName = "Station One",
+                genre = "Jazz",
+                imageUrl = "https://example.com/image.png"
+            )
+        )
+
+        val mediaItem = radio.toMediaItem(contextType = "SEARCH", contextQuery = "gen", page = 2)
+        val extras = mediaItem.mediaMetadata.extras
+
+        assertNotNull("Extras should not be null", extras)
+        assertEquals("SEARCH", extras?.getString("playback_context_type"))
+        assertEquals("gen", extras?.getString("playback_context_query"))
+        assertEquals(2, extras?.getInt("playback_context_page"))
+    }
+}

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerProcessDeathIntegrationTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerProcessDeathIntegrationTest.kt
@@ -1,0 +1,106 @@
+package io.github.agimaulana.radio.core.radioplayer.internal
+
+import android.os.Bundle
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.exoplayer.ExoPlayer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class PlaybackManagerProcessDeathIntegrationTest {
+
+    private lateinit var player: ExoPlayer
+    private lateinit var playbackManager: PlaybackManager
+
+    @Before
+    fun setup() {
+        val context = RuntimeEnvironment.application
+        player = ExoPlayer.Builder(context).build()
+        playbackManager = PlaybackManager(player) { _, _ -> emptyList() }
+    }
+
+    @Test
+    fun restoreFromPlayer_restoresSearchContext() {
+        player.addMediaItem(createMediaItem("id1", "SEARCH", "rock"))
+        player.addMediaItem(createMediaItem("id2", "SEARCH", "rock"))
+        player.addMediaItem(createMediaItem("id3", "SEARCH", "rock"))
+        player.seekTo(1, 0L)
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertEquals(PlaybackManager.PlaybackContext.Type.SEARCH, playbackManager.playbackContext.type)
+        assertEquals("rock", playbackManager.playbackContext.query)
+        assertEquals(setOf("id1", "id2", "id3"), playbackManager.loadedIds)
+    }
+
+    @Test
+    fun restoreFromPlayer_restoresDefaultContext() {
+        player.addMediaItem(createMediaItem("id1", "DEFAULT", null))
+        player.addMediaItem(createMediaItem("id2", "DEFAULT", null))
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertEquals(PlaybackManager.PlaybackContext.Type.DEFAULT, playbackManager.playbackContext.type)
+        assertEquals(null, playbackManager.playbackContext.query)
+        assertEquals(setOf("id1", "id2"), playbackManager.loadedIds)
+    }
+
+    @Test
+    fun restoreFromPlayer_restoresPinnedContext() {
+        player.addMediaItem(createMediaItem("pin1", "PINNED", null))
+        player.addMediaItem(createMediaItem("pin2", "PINNED", null))
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertEquals(PlaybackManager.PlaybackContext.Type.PINNED, playbackManager.playbackContext.type)
+        assertEquals(null, playbackManager.playbackContext.query)
+    }
+
+    @Test
+    fun restoreFromPlayer_EstimatesNextPage() {
+        for (i in 1..25) {
+            player.addMediaItem(createMediaItem("id$i", "DEFAULT", null))
+        }
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertTrue(playbackManager.nextPage >= 3)
+    }
+
+    @Test
+    fun restoreFromPlayer_emptyPlayer_doesNotThrow() {
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertEquals(PlaybackManager.PlaybackContext.Type.DEFAULT, playbackManager.playbackContext.type)
+        assertTrue(playbackManager.loadedIds.isEmpty())
+    }
+
+    private fun createMediaItem(id: String, contextType: String, query: String?): MediaItem {
+        val extras = Bundle()
+        extras.putString("playback_context_type", contextType)
+        if (query != null) {
+            extras.putString("playback_context_query", query)
+        }
+        val metadata = MediaMetadata.Builder()
+            .setExtras(extras)
+            .build()
+        return MediaItem.Builder()
+            .setMediaId(id)
+            .setMediaMetadata(metadata)
+            .setUri("https://example.com/stream")
+            .build()
+    }
+}

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerTest.kt
@@ -1,0 +1,109 @@
+package io.github.agimaulana.radio.core.radioplayer.internal
+
+import android.os.Bundle
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
+import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem.RadioMetadata
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.After
+import org.junit.Test
+import org.robolectric.RobolectricTestRunner
+import org.junit.runner.RunWith
+import io.mockk.every
+import io.mockk.mockk
+
+@RunWith(RobolectricTestRunner::class)
+@Suppress("UNCHECKED_CAST")
+class PlaybackManagerTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun fetchNextPage_appends_filtered_items_and_increments_nextPage() = runBlocking {
+        val player = mockk<Player>(relaxed = true)
+
+        val fetched = listOf(
+            RadioMediaItem("id1", "url1", RadioMetadata("S1", "G", "img")),
+            RadioMediaItem("id2", "url2", RadioMetadata("S2", "G", "img"))
+        )
+
+        val manager = PlaybackManager(player) { nextPage, query -> fetched }
+
+        // simulate that id1 was already loaded to test dedupe
+        val loadedIdsField = PlaybackManager::class.java.getDeclaredField("loadedIds")
+        loadedIdsField.isAccessible = true
+        val loadedIds = loadedIdsField.get(manager) as MutableSet<String>
+        loadedIds.add("id1")
+
+        // call fetchNextPage
+        manager.fetchNextPage()
+
+        // verify that loadedIds contains only id2 as newly added
+        val loadedIdsAfter = loadedIdsField.get(manager) as MutableSet<String>
+        assertTrue(loadedIdsAfter.contains("id2"))
+
+        // nextPage should be incremented to 2
+        val nextPageField = PlaybackManager::class.java.getDeclaredField("nextPage")
+        nextPageField.isAccessible = true
+        val nextPageValue = nextPageField.getInt(manager)
+        assertEquals(2, nextPageValue)
+    }
+
+    @Test
+    fun restoreFromPlayer_sets_playbackContext_and_estimates_nextPage() {
+        val player = mockk<Player>(relaxed = true)
+
+        val extras = Bundle().apply {
+            putString("playback_context_type", "SEARCH")
+            putString("playback_context_query", "gen")
+        }
+        val mediaItem = MediaItem.Builder()
+            .setMediaId("idX")
+            .setMediaMetadata(MediaMetadata.Builder().setExtras(extras).build())
+            .build()
+
+        every { player.currentMediaItem } returns mediaItem
+        every { player.mediaItemCount } returns 25
+
+        val manager = PlaybackManager(player)
+        manager.restoreFromPlayer()
+
+        // nextPage should be (25 / PAGE_SIZE) + 1 => (25/10)+1 = 3
+        val nextPageField = PlaybackManager::class.java.getDeclaredField("nextPage")
+        nextPageField.isAccessible = true
+        val nextPageValue = nextPageField.getInt(manager)
+        assertEquals(3, nextPageValue)
+
+        // playbackContext should be SEARCH with query "gen"
+        val playbackContextField = PlaybackManager::class.java.getDeclaredField("playbackContext")
+        playbackContextField.isAccessible = true
+        val pc = playbackContextField.get(manager)
+        val typeField = pc!!::class.java.getDeclaredField("type")
+        typeField.isAccessible = true
+        val typeValue = typeField.get(pc).toString()
+        val queryField = pc::class.java.getDeclaredField("query")
+        queryField.isAccessible = true
+        val queryValue = queryField.get(pc) as String?
+
+        assertEquals("SEARCH", typeValue)
+        assertEquals("gen", queryValue)
+    }
+}

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerTest.kt
@@ -48,7 +48,7 @@ class PlaybackManagerTest {
         val manager = PlaybackManager(player) { nextPage, query -> fetched }
 
         // simulate that id1 was already loaded to test dedupe
-        val loadedIdsField = PlaybackManager::class.java.getDeclaredField("loadedIds")
+        val loadedIdsField = PlaybackManager::class.java.getDeclaredField("_loadedIds")
         loadedIdsField.isAccessible = true
         val loadedIds = loadedIdsField.get(manager) as MutableSet<String>
         loadedIds.add("id1")
@@ -93,7 +93,7 @@ class PlaybackManagerTest {
         assertEquals(3, nextPageValue)
 
         // playbackContext should be SEARCH with query "gen"
-        val playbackContextField = PlaybackManager::class.java.getDeclaredField("playbackContext")
+        val playbackContextField = PlaybackManager::class.java.getDeclaredField("_playbackContext")
         playbackContextField.isAccessible = true
         val pc = playbackContextField.get(manager)
         val typeField = pc!!::class.java.getDeclaredField("type")

--- a/docs/playback-queue-plan.md
+++ b/docs/playback-queue-plan.md
@@ -75,7 +75,7 @@ Goal
 - ~~Re-register ServiceResolver when _uiState.currentPosition (user location) updates so fetcher calls include latest location~~ (done: StationListViewModel.observeLocationChangesAndReregisterResolver)
 - ~~Run full CI for feat/playback-queue-wip and address any flaky/platform-specific failures.~~ (done: CI passed)
 - ~~Run device smoke tests for notification Prev/Next, pinned→main boundary playback, and search-context restore UI.~~ (done: smoke tests passed)
-- Add integration tests (optional): simulate process death and restore to verify restoreFromPlayer behavior across platforms. (todo: integration-process-death-tests)
+- ~~Add integration tests (optional): simulate process death and restore to verify restoreFromPlayer behavior across platforms.~~ (done: integration-process-death-tests)
 - Consider persisting loaded page ids (DataStore/Room) if playlist restore accuracy is important for the product. (todo: persist-loaded-page-ids)
 - Phase 2: implement backward pagination (prepend) and merged pinned strategy (todo: playback-backward-pagination)
 - Verify Hilt injection for RadioService/PlaybackManager and add providers if missing. (todo: ensure-hilt-injection)

--- a/docs/playback-queue-plan.md
+++ b/docs/playback-queue-plan.md
@@ -1,0 +1,98 @@
+# Playback Queue Plan — Media3 Pagination & Playback Context
+
+## Overview
+
+Problem
+
+The current player pipeline sets a single MediaItem when a station is played. Stations come from a dynamic, paginated, and searchable source and can include pinned stations. This prevents Media3 from exposing previous/next controls and breaks seamless navigation across pages.
+
+Goal
+
+- Provide previous/next controls in player & notification
+- Support forward pagination (append) while playing
+- Keep player layer dumb; orchestration in PlaybackManager (service-side)
+- Handle pinned stations and search contexts cleanly
+- Persist minimal context so playback survives process death
+
+## High-level approach
+
+1. Introduce PlaybackContext data model (DEFAULT, SEARCH, PINNED) and PlaybackQueue representation.
+2. Extend RadioPlayerController API to support playlist operations: setMediaItems(items, startIndex), addMediaItems(items), addMediaItems(index, items), mediaItemCount, currentIndex, and helpers for metadata.
+3. Implement PlaybackManager inside RadioService (MediaSessionService) to own queue state, pagination state, dedup set, and drive ExoPlayer. PlaybackManager listens to player transitions and triggers fetchNextPage when reaching the end.
+4. ViewModel remains thin: send "start playback" intent (with context and items/startIndex) to service via controller/MediaController commands. Service performs on-demand pagination when player reaches end using repository/use-cases.
+5. Persist minimal context in MediaItem.mediaMetadata.extras (context_type, query, page/index). Optionally extend persistence using DataStore/Room later.
+6. Implement pinned Strategy A (separate playback context) initially; merging pins into the main list is Phase 2.
+
+## Files / Components to modify
+
+- core/radioplayer/
+  - RadioPlayerController (interface) — add playlist methods
+  - internal/RadioPlayerControllerImpl — proxy new playlist commands to MediaController (or use SessionCommand)
+  - internal/PlaybackEventFlow — already emits media transitions; ensure suffices
+  - RadioService — add PlaybackManager instance, attach player listener, and expose startPlayback API
+  - (new) PlaybackManager under core/radioplayer/internal
+
+- feature/stationlist/
+  - StationListViewModel — call controller.startPlayback(...) with context + current UI list + startIndex; add search-context banner for restored sessions
+  - Update tests referencing setMediaItem
+
+- domain/ & infrastructure/
+  - Ensure PlaybackManager has access to a small repository interface (or minimal use-case) to request next pages from API
+
+## Implementation order (iterative)
+
+1. Add playlist methods to RadioPlayerController and implement proxies in RadioPlayerControllerImpl. Keep single-item API working.
+2. Create PlaybackManager class; integrate into RadioService. PlaybackManager manages loadedStations, loadedIds, nextPage, isFetching flags, and context.
+3. Implement forward pagination and append via player.addMediaItems(newItems).
+4. Persist minimal PlaybackContext in MediaItem metadata and implement restoreFromPlayer.
+5. Update StationListViewModel to use startPlayback API and add a UI banner to explain restored search context and offer "View results".
+6. Add/adjust unit and integration tests.
+7. Phase 2: backward pagination (prepend) and merged pinned strategy if needed.
+
+## Todos (session tracked)
+- playback-add-controller-playlist-api (done)
+- playback-introduce-playbackmanager (done)
+- playback-service-pagination (done)
+- playback-persist-context (done)
+- stationlist-viewmodel-integration (done)
+- tests-update (done)
+
+## Progress
+- Implemented playlist APIs and ViewModel integration so player receives full in-memory playlist on Play.
+- Added PlaybackManager and wired forward pagination fetching via a runtime resolver; PlaybackManager appends new items using addMediaItems.
+- Implemented combined pinned-first playlist behavior: when playing from pinned UI, the playlist is pinnedStations first followed by the current main list (duplicates removed). startIndex is computed against the combined list so Prev/Next cross the pinned→main boundary correctly.
+- Unit tests added/updated:
+  - core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItemTest.kt — verifies playback_context_type/query/page extras are attached by RadioMediaItem.toMediaItem.
+  - core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerTest.kt — verifies fetchNextPage dedupe/appending behavior and restoreFromPlayer page estimation and playback context restoration.
+- StationListViewModel changes:
+  - Use pinnedStations as playlist source for pinned-only playback (previous behavior).
+  - Implemented pinned-first combined playlist to continue into the main list after pinned items (current implementation).
+  - Resolver registration remains in init(); plan updated to re-register resolver when currentPosition (user location) changes so fetches include latest location.
+- Local test run: core:radioplayer unit tests executed locally after adding test dependencies and minor testability adjustments; tests and commits are on feat/playback-queue-wip.
+- Confirmed notification shows prev/next and buttons behave as expected in most scenarios. When playback starts at the first item of the default list, the previous action is not available (expected behavior).
+
+## Next steps
+- ~~Re-register ServiceResolver when _uiState.currentPosition (user location) updates so fetcher calls include latest location~~ (done: StationListViewModel.observeLocationChangesAndReregisterResolver)
+- ~~Run full CI for feat/playback-queue-wip and address any flaky/platform-specific failures.~~ (done: CI passed)
+- ~~Run device smoke tests for notification Prev/Next, pinned→main boundary playback, and search-context restore UI.~~ (done: smoke tests passed)
+- Add integration tests (optional): simulate process death and restore to verify restoreFromPlayer behavior across platforms. (todo: integration-process-death-tests)
+- Consider persisting loaded page ids (DataStore/Room) if playlist restore accuracy is important for the product. (todo: persist-loaded-page-ids)
+- Phase 2: implement backward pagination (prepend) and merged pinned strategy (todo: playback-backward-pagination)
+- Verify Hilt injection for RadioService/PlaybackManager and add providers if missing. (todo: ensure-hilt-injection)
+
+
+## UX notes
+- Don’t auto-enter search UI after process death. Restore playback and show a banner "Playing from search: 'keyword'" with an option to view results.
+
+## Persistence & Restore
+- Store minimal context inside MediaItem.mediaMetadata.extras so MediaSessionService/ExoPlayer playlist is the primary source of truth.
+- Estimate nextPage by player.mediaItemCount / PAGE_SIZE as fallback. Optionally persist loaded page numbers for accuracy.
+
+## Risks & Mitigations
+- Index desync during prepend: defer to Phase 2
+- API break: keep old single-item path working while migrating
+- Service needs access to repository/use-cases: inject small repository interface into RadioService (Hilt)
+
+---
+
+This document is committed to the repository so work can continue across interruptions. For incremental work, update the session's todos (tracked via the SQL todos table) and reference this document.

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -11,6 +11,8 @@ import io.github.agimaulana.radio.core.radioplayer.PlaybackState
 import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
+import io.github.agimaulana.radio.core.radioplayer.internal.ServiceResolver.registerGetRadioStationsResolver
+import io.github.agimaulana.radio.core.radioplayer.internal.ServiceResolver.clearGetRadioStationsResolver
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.PinnedStationLimitReachedException
@@ -38,6 +40,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class StationListViewModel @Inject constructor(
     private val getRadioStationsUseCase: GetRadioStationsUseCase,
@@ -59,6 +62,8 @@ class StationListViewModel @Inject constructor(
     private var searchJob: Job? = null
     private var fetchJob: Job? = null
     private var pinnedStationsJob: Job? = null
+    private var locationChangeJob: Job? = null
+    private var lastRegisteredPosition: GeoLatLong? = null
 
     fun init(
         hasLocationPermission: Boolean = false,
@@ -74,9 +79,49 @@ class StationListViewModel @Inject constructor(
             radioPlayerController = radioPlayerControllerFactory.get().apply {
                 viewModelScope.launch { event.collect(::onPlaybackEventReceived) }
             }
+            // Register domain use-case with Playback service resolver so PlaybackManager can call it when needed.
+            try {
+                registerGetRadioStationsResolver { page, query ->
+                    // Use current UI location if available; location param in use case is optional
+                    val location = _uiState.value.currentPosition
+                    getRadioStationsUseCase.execute(
+                        page = page,
+                        searchName = query,
+                        location = location
+                    ).map { rs -> rs.toRadioMediaItem() }
+                }
+            } catch (e: Exception) {
+                // no-op if resolver not available at runtime
+                Timber.e(e, "Not available resolver")
+            }
             restoreSelectedStation()
         }
         observePinnedStations()
+        observeLocationChangesAndReregisterResolver()
+    }
+
+    private fun observeLocationChangesAndReregisterResolver() {
+        locationChangeJob?.cancel()
+        locationChangeJob = viewModelScope.launch {
+            _uiState.collect { state ->
+                val newPosition = state.currentPosition
+                if (newPosition != lastRegisteredPosition) {
+                    lastRegisteredPosition = newPosition
+                    try {
+                        registerGetRadioStationsResolver { page, query ->
+                            val location = _uiState.value.currentPosition
+                            getRadioStationsUseCase.execute(
+                                page = page,
+                                searchName = query,
+                                location = location
+                            ).map { rs -> rs.toRadioMediaItem() }
+                        }
+                    } catch (e: Exception) {
+                        Timber.e(e, "Failed to update resolver on location change")
+                    }
+                }
+            }
+        }
     }
 
     private fun observePinnedStations() {
@@ -87,8 +132,12 @@ class StationListViewModel @Inject constructor(
                 _uiState.update { state ->
                     state.copy(
                         isPinnedStationsLoading = false,
-                        pinnedStations = pinned.map { it.toUiStateStation(pinnedUuids) }.toImmutableList(),
-                        stations = state.stations.map { it.copy(isPinned = it.serverUuid in pinnedUuids) }.toPersistentList()
+                        pinnedStations = pinned.map {
+                            it.toUiStateStation(pinnedUuids)
+                        }.toImmutableList(),
+                        stations = state.stations.map {
+                            it.copy(isPinned = it.serverUuid in pinnedUuids)
+                        }.toPersistentList()
                     )
                 }
             }
@@ -99,15 +148,11 @@ class StationListViewModel @Inject constructor(
         val mediaId = radioPlayerController?.currentMediaId ?: return
         if (mediaId.isNotEmpty()) {
             val station = getRadioStationUseCase.execute(mediaId)
-            val uiStation = station.toUiStateStation(emptySet()).copy(isPlaying = radioPlayerController?.isPlaying == true)
+            val uiStation = station.toUiStateStation(emptySet())
+                .copy(isPlaying = radioPlayerController?.isPlaying == true)
             _uiState.update { it.copy(selectedStation = uiStation) }
             updatePlayerColors(uiStation.imageUrl)
         }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        radioPlayerController?.release()
     }
 
     fun onAction(action: Action) {
@@ -123,8 +168,48 @@ class StationListViewModel @Inject constructor(
                 radioPlayerController?.pause()
             }
             is Action.Play -> {
-                stationListTracker.trackPlaybackResumed(_uiState.value.selectedStation?.serverUuid)
-                radioPlayerController?.play()
+                val stationToPlay = action.station
+                stationListTracker.trackPlaybackResumed(stationToPlay.serverUuid)
+
+                if (radioPlayerController?.currentMediaId == stationToPlay.serverUuid) {
+                    // already loaded; just resume
+                    radioPlayerController?.play()
+                } else {
+                    // Build playlist: if playing a pinned station, put pinned stations first then remaining stations without duplicates
+                    val pinned = _uiState.value.pinnedStations
+                    val main = _uiState.value.stations
+                    val combined = if (stationToPlay.isPinned) {
+                        val pinnedIds = pinned.map { it.serverUuid }.toSet()
+                        pinned + main.filterNot { it.serverUuid in pinnedIds }
+                    } else {
+                        main
+                    }
+                    val startIndex = combined.indexOfFirst { it.serverUuid == stationToPlay.serverUuid }
+
+                    if (startIndex >= 0) {
+                        val playlist = combined.map { it.toRadioMediaItem() }
+                        radioPlayerController?.apply {
+                            startPlayback(
+                                items = playlist,
+                                startIndex = startIndex,
+                                // Use SEARCH context if filtering, otherwise DEFAULT
+                                contextType = if (!_uiState.value.filterStationName.isNullOrEmpty()) {
+                                    "SEARCH"
+                                } else {
+                                    null
+                                },
+                                contextQuery = _uiState.value.filterStationName
+                            )
+                        }
+                    } else {
+                        // Fallback to single item (pinned or not in list)
+                        radioPlayerController?.apply {
+                            setMediaItem(stationToPlay.toRadioMediaItem())
+                            prepare()
+                            play()
+                        }
+                    }
+                }
             }
             is Action.Stop -> {
                 stationListTracker.trackPlaybackStopped(action.station.serverUuid)
@@ -187,12 +272,46 @@ class StationListViewModel @Inject constructor(
                 radioPlayerController?.play()
             }
         } else {
-            stationListTracker.trackStationSelected(station.serverUuid, station.name)
-            radioPlayerController?.apply {
-                setMediaItem(station.toRadioMediaItem())
-                prepare()
-                play()
+            stationListTracker.trackStationSelected(
+                stationId = station.serverUuid,
+                stationName = station.name
+            )
+
+            // Build playlist: if clicking a pinned station, put pinned stations first then remaining stations without duplicates
+            val pinned = _uiState.value.pinnedStations
+            val main = _uiState.value.stations
+            val combined = if (station.isPinned) {
+                val pinnedIds = pinned.map { it.serverUuid }.toSet()
+                pinned + main.filterNot { it.serverUuid in pinnedIds }
+            } else {
+                main
             }
+            val startIndex = combined.indexOfFirst { it.serverUuid == station.serverUuid }
+
+            if (startIndex >= 0) {
+                val playlist = combined.map { it.toRadioMediaItem() }
+                radioPlayerController?.apply {
+                    startPlayback(
+                        items = playlist,
+                        startIndex = startIndex,
+                        // Use SEARCH context if filtering, otherwise DEFAULT
+                        contextType = if (!_uiState.value.filterStationName.isNullOrEmpty()) {
+                            "SEARCH"
+                        } else {
+                            null
+                        },
+                        contextQuery = _uiState.value.filterStationName
+                    )
+                }
+            } else {
+                // Fallback: station not found in in-memory list (e.g., pinned or stale). Play single item.
+                radioPlayerController?.apply {
+                    setMediaItem(station.toRadioMediaItem())
+                    prepare()
+                    play()
+                }
+            }
+
             updatePlayerColors(station.imageUrl)
         }
     }
@@ -255,8 +374,21 @@ class StationListViewModel @Inject constructor(
 
     private fun trackPlayerEvent(source: String, expanded: Boolean) {
         val s = _uiState.value.selectedStation
-        if (expanded) stationListTracker.trackPlayerExpanded(source, s?.serverUuid, s?.name, s?.isPlaying == true)
-        else stationListTracker.trackPlayerCollapsed(source, s?.serverUuid, s?.name, s?.isPlaying == true)
+        if (expanded) {
+            stationListTracker.trackPlayerExpanded(
+                source = source,
+                stationId = s?.serverUuid,
+                stationName = s?.name,
+                isPlaying = s?.isPlaying == true
+            )
+        } else {
+            stationListTracker.trackPlayerCollapsed(
+                source = source,
+                stationId = s?.serverUuid,
+                stationName = s?.name,
+                isPlaying = s?.isPlaying == true
+            )
+        }
     }
 
     private fun fetchRadioStations(force: Boolean = false) {
@@ -275,7 +407,7 @@ class StationListViewModel @Inject constructor(
                     location = _uiState.value.currentPosition,
                 ).map {
                     val isCurrentlyPlaying = (radioPlayerController?.currentMediaId == it.stationUuid)
-                            && (radioPlayerController?.isPlaying == true)
+                        && (radioPlayerController?.isPlaying == true)
                     it.toUiStateStation(pinnedUuids).copy(isPlaying = isCurrentlyPlaying)
                 }.toPersistentList()
                 _uiState.update {
@@ -313,7 +445,11 @@ class StationListViewModel @Inject constructor(
                 )
             }
             is PlaybackEvent.StateChanged -> _uiState.update {
-                it.copy(selectedStation = station?.copy(isBuffering = playbackEvent.state == PlaybackState.BUFFERING))
+                it.copy(
+                    selectedStation = station?.copy(
+                        isBuffering = playbackEvent.state == PlaybackState.BUFFERING
+                    )
+                )
             }
             is PlaybackEvent.MediaItemTransition -> playbackEvent.mediaId?.let { mediaId ->
                 viewModelScope.launch {
@@ -377,6 +513,16 @@ class StationListViewModel @Inject constructor(
         )
     }
 
+    override fun onCleared() {
+        super.onCleared()
+        searchJob?.cancel()
+        fetchJob?.cancel()
+        pinnedStationsJob?.cancel()
+        locationChangeJob?.cancel()
+        clearGetRadioStationsResolver()
+        radioPlayerController?.release()
+    }
+
     sealed interface Action {
         data object LoadMore : Action
         data class Search(val stationName: String) : Action
@@ -403,7 +549,9 @@ class StationListViewModel @Inject constructor(
     }
 }
 
-private fun RadioStation.toUiStateStation(pinnedUuids: Set<String>) = StationListViewModel.UiState.Station(
+private fun RadioStation.toUiStateStation(
+    pinnedUuids: Set<String>
+) = StationListViewModel.UiState.Station(
     serverUuid = stationUuid,
     name = name,
     genre = tags.getOrNull(0).orEmpty(),
@@ -418,6 +566,16 @@ private fun StationListViewModel.UiState.Station.toRadioMediaItem() = RadioMedia
     mediaId = serverUuid,
     streamUrl = streamUrl,
     radioMetadata = RadioMediaItem.RadioMetadata(name, genre, imageUrl)
+)
+
+private fun RadioStation.toRadioMediaItem() = RadioMediaItem(
+    mediaId = stationUuid,
+    streamUrl = url,
+    radioMetadata = RadioMediaItem.RadioMetadata(
+        stationName = name,
+        genre = tags.getOrNull(0).orEmpty(),
+        imageUrl = imageUrl
+    )
 )
 
 private fun ImmutableList<StationListViewModel.UiState.Station>.togglePlayingStateForStations(


### PR DESCRIPTION
## Summary
- Add `PlaybackManagerProcessDeathIntegrationTest` with 5 test cases covering SEARCH, DEFAULT, PINNED context restoration, nextPage estimation, and empty player edge case
- Expose internal getters in `PlaybackManager` for `loadedIds`, `playbackContext`, and `nextPage` for testing
- Update existing unit tests to use renamed private fields (`_loadedIds`, `_playbackContext`)
- Mark `integration-process-death-tests` as done in `playback-queue-plan.md`

## Tests
- 8 unit tests pass (5 new + 2 existing + 1 RadioMediaItemTest)