### PR TITLE
test: add integration tests for restoreFromPlayer process death

### DIFF
--- a/core/radioplayer/build.gradle.kts
+++ b/core/radioplayer/build.gradle.kts
@@ -15,4 +15,10 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+
+    androidTestImplementation(libs.androidx.media3.session)
+    androidTestImplementation(libs.androidx.media3.exoplayer)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManager.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManager.kt
@@ -28,15 +28,20 @@ internal class PlaybackManager(
     private val scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
 
     private val loadedItems = mutableListOf<RadioMediaItem>()
-    private val loadedIds = mutableSetOf<String>()
 
-    private var nextPage: Int = 1
     private var isFetchingNextPage: Boolean = false
 
-    private var playbackContext: PlaybackContext = PlaybackContext(
+    private var _playbackContext: PlaybackContext = PlaybackContext(
         type = PlaybackContext.Type.DEFAULT,
         query = null
     )
+    internal val playbackContext: PlaybackContext get() = _playbackContext
+
+    private var _loadedIds: MutableSet<String> = mutableSetOf()
+    internal val loadedIds: Set<String> get() = _loadedIds
+
+    internal var nextPage: Int = 1
+        private set
 
     private val playerListener = object : androidx.media3.common.Player.Listener {
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -63,14 +68,14 @@ internal class PlaybackManager(
         scope.launch {
             // Reset state
             loadedItems.clear()
-            loadedIds.clear()
+            _loadedIds.clear()
 
             loadedItems.addAll(items)
-            loadedIds.addAll(items.map { it.mediaId })
+            _loadedIds.addAll(items.map { it.mediaId })
 
             // Calculate starting page based on items size to avoid re-fetching initial pages
             nextPage = (items.size / PAGE_SIZE) + 1
-            playbackContext = context
+            _playbackContext = context
 
             val mediaItems = items.map {
                 it.toMediaItem(
@@ -87,16 +92,16 @@ internal class PlaybackManager(
 
     fun addMediaItems(items: List<RadioMediaItem>) {
         scope.launch {
-            val filtered = items.filterNot { loadedIds.contains(it.mediaId) }
+            val filtered = items.filterNot { _loadedIds.contains(it.mediaId) }
             if (filtered.isEmpty()) return@launch
 
             loadedItems.addAll(filtered)
-            loadedIds.addAll(filtered.map { it.mediaId })
+            _loadedIds.addAll(filtered.map { it.mediaId })
 
             val mediaItems = filtered.map {
                 it.toMediaItem(
-                    contextType = playbackContext.type.name,
-                    contextQuery = playbackContext.query,
+                    contextType = _playbackContext.type.name,
+                    contextQuery = _playbackContext.query,
                     page = null
                 )
             }
@@ -106,16 +111,16 @@ internal class PlaybackManager(
 
     fun addMediaItems(index: Int, items: List<RadioMediaItem>) {
         scope.launch {
-            val filtered = items.filterNot { loadedIds.contains(it.mediaId) }
+            val filtered = items.filterNot { _loadedIds.contains(it.mediaId) }
             if (filtered.isEmpty()) return@launch
 
             loadedItems.addAll(index, filtered)
-            loadedIds.addAll(filtered.map { it.mediaId })
+            _loadedIds.addAll(filtered.map { it.mediaId })
 
             val mediaItems = filtered.map {
                 it.toMediaItem(
-                    contextType = playbackContext.type.name,
-                    contextQuery = playbackContext.query,
+                    contextType = _playbackContext.type.name,
+                    contextQuery = _playbackContext.query,
                     page = null
                 )
             }
@@ -128,7 +133,7 @@ internal class PlaybackManager(
         val isAtEnd = player.currentMediaItemIndex == player.mediaItemCount - 1
         if (!isAtEnd) return
         if (isFetchingNextPage) return
-        if (playbackContext.type == PlaybackContext.Type.PINNED) return
+        if (_playbackContext.type == PlaybackContext.Type.PINNED) return
 
         scope.launch {
             fetchNextPage()
@@ -139,17 +144,17 @@ internal class PlaybackManager(
         if (isFetchingNextPage) return
         isFetchingNextPage = true
         try {
-            val newItems = fetcher(nextPage, playbackContext.query)
+            val newItems = fetcher(nextPage, _playbackContext.query)
             if (newItems.isNotEmpty()) {
-                val filtered = newItems.filterNot { loadedIds.contains(it.mediaId) }
+                val filtered = newItems.filterNot { _loadedIds.contains(it.mediaId) }
                 if (filtered.isNotEmpty()) {
                     // append
                     loadedItems.addAll(filtered)
-                    loadedIds.addAll(filtered.map { it.mediaId })
+                    _loadedIds.addAll(filtered.map { it.mediaId })
                     val mediaItems = filtered.map {
                         it.toMediaItem(
-                            contextType = playbackContext.type.name,
-                            contextQuery = playbackContext.query,
+                            contextType = _playbackContext.type.name,
+                            contextQuery = _playbackContext.query,
                             page = nextPage
                         )
                     }
@@ -173,7 +178,7 @@ internal class PlaybackManager(
         val extras = current.mediaMetadata.extras
         val typeName = extras?.getString("playback_context_type") ?: PlaybackContext.Type.DEFAULT.name
         val query = extras?.getString("playback_context_query")
-        playbackContext = try {
+        _playbackContext = try {
             PlaybackContext(PlaybackContext.Type.valueOf(typeName), query)
         } catch (e: Exception) {
             Timber.i(e)
@@ -181,9 +186,9 @@ internal class PlaybackManager(
         }
 
         // Restore loadedIds from current player items to avoid duplicates during pagination
-        loadedIds.clear()
+        _loadedIds.clear()
         repeat(player.mediaItemCount) { index ->
-            player.getMediaItemAt(index).mediaId?.let { loadedIds.add(it) }
+            player.getMediaItemAt(index).mediaId?.let { _loadedIds.add(it) }
         }
 
         // Estimate next page from current playlist size

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerProcessDeathIntegrationTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerProcessDeathIntegrationTest.kt
@@ -1,0 +1,106 @@
+package io.github.agimaulana.radio.core.radioplayer.internal
+
+import android.os.Bundle
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.exoplayer.ExoPlayer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class PlaybackManagerProcessDeathIntegrationTest {
+
+    private lateinit var player: ExoPlayer
+    private lateinit var playbackManager: PlaybackManager
+
+    @Before
+    fun setup() {
+        val context = RuntimeEnvironment.application
+        player = ExoPlayer.Builder(context).build()
+        playbackManager = PlaybackManager(player) { _, _ -> emptyList() }
+    }
+
+    @Test
+    fun restoreFromPlayer_restoresSearchContext() {
+        player.addMediaItem(createMediaItem("id1", "SEARCH", "rock"))
+        player.addMediaItem(createMediaItem("id2", "SEARCH", "rock"))
+        player.addMediaItem(createMediaItem("id3", "SEARCH", "rock"))
+        player.seekTo(1, 0L)
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertEquals(PlaybackManager.PlaybackContext.Type.SEARCH, playbackManager.playbackContext.type)
+        assertEquals("rock", playbackManager.playbackContext.query)
+        assertEquals(setOf("id1", "id2", "id3"), playbackManager.loadedIds)
+    }
+
+    @Test
+    fun restoreFromPlayer_restoresDefaultContext() {
+        player.addMediaItem(createMediaItem("id1", "DEFAULT", null))
+        player.addMediaItem(createMediaItem("id2", "DEFAULT", null))
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertEquals(PlaybackManager.PlaybackContext.Type.DEFAULT, playbackManager.playbackContext.type)
+        assertEquals(null, playbackManager.playbackContext.query)
+        assertEquals(setOf("id1", "id2"), playbackManager.loadedIds)
+    }
+
+    @Test
+    fun restoreFromPlayer_restoresPinnedContext() {
+        player.addMediaItem(createMediaItem("pin1", "PINNED", null))
+        player.addMediaItem(createMediaItem("pin2", "PINNED", null))
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertEquals(PlaybackManager.PlaybackContext.Type.PINNED, playbackManager.playbackContext.type)
+        assertEquals(null, playbackManager.playbackContext.query)
+    }
+
+    @Test
+    fun restoreFromPlayer_EstimatesNextPage() {
+        for (i in 1..25) {
+            player.addMediaItem(createMediaItem("id$i", "DEFAULT", null))
+        }
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertTrue(playbackManager.nextPage >= 3)
+    }
+
+    @Test
+    fun restoreFromPlayer_emptyPlayer_doesNotThrow() {
+        player.prepare()
+
+        playbackManager.restoreFromPlayer()
+
+        assertEquals(PlaybackManager.PlaybackContext.Type.DEFAULT, playbackManager.playbackContext.type)
+        assertTrue(playbackManager.loadedIds.isEmpty())
+    }
+
+    private fun createMediaItem(id: String, contextType: String, query: String?): MediaItem {
+        val extras = Bundle()
+        extras.putString("playback_context_type", contextType)
+        if (query != null) {
+            extras.putString("playback_context_query", query)
+        }
+        val metadata = MediaMetadata.Builder()
+            .setExtras(extras)
+            .build()
+        return MediaItem.Builder()
+            .setMediaId(id)
+            .setMediaMetadata(metadata)
+            .setUri("https://example.com/stream")
+            .build()
+    }
+}

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackManagerTest.kt
@@ -48,7 +48,7 @@ class PlaybackManagerTest {
         val manager = PlaybackManager(player) { nextPage, query -> fetched }
 
         // simulate that id1 was already loaded to test dedupe
-        val loadedIdsField = PlaybackManager::class.java.getDeclaredField("loadedIds")
+        val loadedIdsField = PlaybackManager::class.java.getDeclaredField("_loadedIds")
         loadedIdsField.isAccessible = true
         val loadedIds = loadedIdsField.get(manager) as MutableSet<String>
         loadedIds.add("id1")
@@ -93,7 +93,7 @@ class PlaybackManagerTest {
         assertEquals(3, nextPageValue)
 
         // playbackContext should be SEARCH with query "gen"
-        val playbackContextField = PlaybackManager::class.java.getDeclaredField("playbackContext")
+        val playbackContextField = PlaybackManager::class.java.getDeclaredField("_playbackContext")
         playbackContextField.isAccessible = true
         val pc = playbackContextField.get(manager)
         val typeField = pc!!::class.java.getDeclaredField("type")

--- a/docs/playback-queue-plan.md
+++ b/docs/playback-queue-plan.md
@@ -75,7 +75,7 @@ Goal
 - ~~Re-register ServiceResolver when _uiState.currentPosition (user location) updates so fetcher calls include latest location~~ (done: StationListViewModel.observeLocationChangesAndReregisterResolver)
 - ~~Run full CI for feat/playback-queue-wip and address any flaky/platform-specific failures.~~ (done: CI passed)
 - ~~Run device smoke tests for notification Prev/Next, pinned→main boundary playback, and search-context restore UI.~~ (done: smoke tests passed)
-- Add integration tests (optional): simulate process death and restore to verify restoreFromPlayer behavior across platforms. (todo: integration-process-death-tests)
+- ~~Add integration tests (optional): simulate process death and restore to verify restoreFromPlayer behavior across platforms.~~ (done: integration-process-death-tests)
 - Consider persisting loaded page ids (DataStore/Room) if playlist restore accuracy is important for the product. (todo: persist-loaded-page-ids)
 - Phase 2: implement backward pagination (prepend) and merged pinned strategy (todo: playback-backward-pagination)
 - Verify Hilt injection for RadioService/PlaybackManager and add providers if missing. (todo: ensure-hilt-injection)


### PR DESCRIPTION
## Summary
- Add `PlaybackManagerProcessDeathIntegrationTest` with 5 test cases covering SEARCH, DEFAULT, PINNED context restoration, nextPage estimation, and empty player edge case
- Expose internal getters in `PlaybackManager` for `loadedIds`, `playbackContext`, and `nextPage` for testing
- Update existing unit tests to use renamed private fields (`_loadedIds`, `_playbackContext`)
- Mark `integration-process-death-tests` as done in `playback-queue-plan.md`

## Tests
- 8 unit tests pass (5 new + 2 existing + 1 RadioMediaItemTest)