### PR TITLE
feat: add Hilt injection for RadioService and PlaybackManager

### DIFF
--- a/core/radioplayer/build.gradle.kts
+++ b/core/radioplayer/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id(libs.plugins.boilerplate.android.library.asProvider().get().pluginId)
+    id(libs.plugins.boilerplate.android.hilt.get().pluginId)
 }
 
 android {
@@ -10,6 +11,10 @@ dependencies {
     implementation(libs.androidx.media3.session)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.exoplayer.hls)
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.android.compiler)
+    implementation(project(":domain:api"))
+    implementation(project(":domain:impl"))
 
     testImplementation(libs.robolectric)
     testImplementation(libs.junit)

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
@@ -12,47 +12,51 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
+import dagger.hilt.android.AndroidEntryPoint
 import io.github.agimaulana.radio.core.radioplayer.internal.PlaybackManager
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioMediaSessionCallback
 import io.github.agimaulana.radio.core.radioplayer.internal.ServiceResolver
+import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
+import javax.inject.Inject
 
 @OptIn(UnstableApi::class)
+@AndroidEntryPoint
 class RadioService : MediaSessionService() {
+    @Inject lateinit var getRadioStationsUseCase: GetRadioStationsUseCase
+
     private var mediaSession: MediaSession? = null
     private var playbackManager: PlaybackManager? = null
 
     override fun onCreate() {
         super.onCreate()
         val player = createPlayer()
-        // Initialize PlaybackManager with a no-op fetcher for now. The fetcher will be injected/wired later
-        // Wire a fetcher that calls the domain use-case via a lazy resolver to avoid tight coupling in module boundaries.
-        playbackManager = PlaybackManager(player) { page, query ->
-            val resolver = ServiceResolver.resolveGetRadioStationsResolver()
-            if (resolver != null) {
-                try {
-                    resolver.invoke(page, query)
-                } catch (e: Exception) {
-                    if (e is kotlinx.coroutines.CancellationException) {
-                        throw e
-                    }
-                    emptyList()
-                }
-            } else emptyList()
-        }
 
-        // Register PlaybackManager.startPlayback with ServiceResolver so controller can call it
-        playbackManager?.let { manager ->
-            ServiceResolver.registerPlaybackStartCallback { items, startIndex, contextType, contextQuery ->
-                val type = contextType?.let { ct ->
-                    runCatching { PlaybackManager.PlaybackContext.Type.valueOf(ct) }
-                        .getOrElse { PlaybackManager.PlaybackContext.Type.DEFAULT }
-                } ?: PlaybackManager.PlaybackContext.Type.DEFAULT
-                manager.startPlayback(
-                    items,
-                    startIndex,
-                    PlaybackManager.PlaybackContext(type = type, query = contextQuery)
-                )
-            }
+        val fetcher: suspend (Int, String?) -> List<RadioMediaItem> = { page, query ->
+            getRadioStationsUseCase.execute(page = page, searchName = query, location = null)
+                .map { station ->
+                    RadioMediaItem(
+                        mediaId = station.stationUuid,
+                        streamUrl = station.resolvedUrl.ifEmpty { station.url },
+                        radioMetadata = RadioMediaItem.RadioMetadata(
+                            stationName = station.name,
+                            genre = station.tags.firstOrNull() ?: "",
+                            imageUrl = station.imageUrl
+                        )
+                    )
+                }
+        }
+        playbackManager = PlaybackManager(player, fetcher)
+
+        ServiceResolver.registerPlaybackStartCallback { items, startIndex, contextType, contextQuery ->
+            val type = contextType?.let { ct ->
+                runCatching { PlaybackManager.PlaybackContext.Type.valueOf(ct) }
+                    .getOrElse { PlaybackManager.PlaybackContext.Type.DEFAULT }
+            } ?: PlaybackManager.PlaybackContext.Type.DEFAULT
+            playbackManager?.startPlayback(
+                items,
+                startIndex,
+                PlaybackManager.PlaybackContext(type = type, query = contextQuery)
+            )
         }
 
         mediaSession = MediaSession.Builder(this, player)
@@ -61,7 +65,6 @@ class RadioService : MediaSessionService() {
             .build()
         setMediaNotificationProvider(DefaultMediaNotificationProvider.Builder(this).build())
 
-        // Attempt to restore playback context from player playlist (if any persisted metadata exists)
         playbackManager?.restoreFromPlayer()
     }
 

--- a/domain/impl/build.gradle.kts
+++ b/domain/impl/build.gradle.kts
@@ -1,6 +1,7 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     id(libs.plugins.boilerplate.android.library.asProvider().get().pluginId)
+    id(libs.plugins.boilerplate.android.hilt.get().pluginId)
 }
 
 android {
@@ -9,6 +10,8 @@ android {
 
 dependencies {
     implementation(libs.moshi)
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.android.compiler)
     implementation(project(":core:common"))
     implementation(project(":domain:api"))
 

--- a/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/di/ServiceModule.kt
+++ b/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/di/ServiceModule.kt
@@ -1,0 +1,20 @@
+package io.github.agimaulana.radio.domain.impl.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
+import io.github.agimaulana.radio.domain.impl.GetRadioStationsUseCaseImpl
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface ServiceModule {
+
+    @Binds
+    @Singleton
+    fun bindGetRadioStationsUseCase(
+        impl: GetRadioStationsUseCaseImpl
+    ): GetRadioStationsUseCase
+}

--- a/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/di/UseCaseModule.kt
+++ b/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/di/UseCaseModule.kt
@@ -6,21 +6,16 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
-import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.PinStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.UnpinStationUseCase
 import io.github.agimaulana.radio.domain.impl.GetPinnedStationsUseCaseImpl
 import io.github.agimaulana.radio.domain.impl.GetRadioStationUseCaseImpl
-import io.github.agimaulana.radio.domain.impl.GetRadioStationsUseCaseImpl
 import io.github.agimaulana.radio.domain.impl.PinStationUseCaseImpl
 import io.github.agimaulana.radio.domain.impl.UnpinStationUseCaseImpl
 
 @Module
 @InstallIn(ViewModelComponent::class)
 interface UseCaseModule {
-
-    @Binds
-    fun bindGetRadioStationsUseCase(impl: GetRadioStationsUseCaseImpl): GetRadioStationsUseCase
 
     @Binds
     fun bindGetRadioStationUseCase(impl: GetRadioStationUseCaseImpl): GetRadioStationUseCase


### PR DESCRIPTION
## Summary
- Add `@AndroidEntryPoint` to RadioService to enable Hilt DI
- Inject `GetRadioStationsUseCase` directly into RadioService
- Create `ServiceModule` to provide use case at `SingletonComponent` level
- Add Hilt plugin to `domain:impl` module

This completes the TODO from `docs/playback-queue-plan.md`:
> Verify Hilt injection for RadioService/PlaybackManager and add providers if missing

## Changes
- `core/radioplayer/build.gradle.kts` - Added Hilt plugin, domain dependencies
- `core/radioplayer/.../RadioService.kt` - Added @AndroidEntryPoint, @Inject for use case
- `domain/impl/.../ServiceModule.kt` (new) - Provides GetRadioStationsUseCase at Singleton level
- `domain/impl/build.gradle.kts` - Added Hilt plugin
- `domain/impl/.../UseCaseModule.kt` - Removed duplicate GetRadioStationsUseCase binding

## Verification
- ✅ `./gradlew assembleDevDebug` - BUILD SUCCESSFUL
- ✅ `./gradlew testDevDebugUnitTest` - BUILD SUCCESSFUL
- ✅ `./gradlew detekt` - BUILD SUCCESSFUL