### PR TITLE
Fix: Align Media3 Control Flow

### DIFF
--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/PlaybackEvent.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/PlaybackEvent.kt
@@ -4,4 +4,5 @@ sealed interface PlaybackEvent {
     data class StateChanged(val state: PlaybackState) : PlaybackEvent
     data class PlayingChanged(val isPlaying: Boolean) : PlaybackEvent
     data class MediaItemTransition(val mediaId: String?) : PlaybackEvent
+    data object PlaylistChanged : PlaybackEvent
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItem.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItem.kt
@@ -43,3 +43,13 @@ internal fun RadioMediaItem.toMediaItem(
         .setMediaMetadata(metadataBuilder.build())
         .build()
 }
+
+fun MediaItem.toRadioMediaItem() = RadioMediaItem(
+    mediaId = mediaId,
+    streamUrl = localConfiguration?.uri?.toString().orEmpty(),
+    radioMetadata = RadioMediaItem.RadioMetadata(
+        stationName = mediaMetadata.title?.toString().orEmpty(),
+        genre = mediaMetadata.subtitle?.toString().orEmpty(),
+        imageUrl = mediaMetadata.artworkUri?.toString().orEmpty()
+    )
+)

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioPlayerController.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioPlayerController.kt
@@ -35,6 +35,8 @@ interface RadioPlayerController {
         context: PlaybackContext = PlaybackContext(DEFAULT, null)
     )
 
+    fun getPlaylist(): List<RadioMediaItem>
+
     val mediaItemCount: Int
     val currentMediaItemIndex: Int
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioLibraryCatalog
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioSessionCallback
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
+import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -29,6 +30,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class RadioService : MediaLibraryService() {
     @Inject lateinit var getRadioStationsUseCase: GetRadioStationsUseCase
+    @Inject lateinit var getRadioStationUseCase: GetRadioStationUseCase
     @Inject lateinit var catalogStateRepository: CatalogStateRepository
 
     private var mediaSession: MediaLibraryService.MediaLibrarySession? = null
@@ -39,7 +41,11 @@ class RadioService : MediaLibraryService() {
 
     override fun onCreate() {
         super.onCreate()
-        radioLibraryCatalog = RadioLibraryCatalog(getRadioStationsUseCase, catalogStateRepository)
+        radioLibraryCatalog = RadioLibraryCatalog(
+            getRadioStationsUseCase,
+            getRadioStationUseCase,
+            catalogStateRepository
+        )
         val player = createPlayer()
         radioSessionCallback = RadioSessionCallback(radioLibraryCatalog)
 
@@ -95,8 +101,8 @@ class RadioService : MediaLibraryService() {
                 val currentIndex = player.currentMediaItemIndex
                 val playlistSize = player.mediaItemCount
                 if (!isLoadingNextPage && currentIndex >= playlistSize - 2 && playlistSize > 0) {
+                    isLoadingNextPage = true
                     serviceScope.launch {
-                        isLoadingNextPage = true
                         try {
                             val nextPage = (playlistSize / RadioLibraryCatalog.CATALOG_PAGE_SIZE)
                             val newItems = radioLibraryCatalog.loadChildren(

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
@@ -18,6 +18,11 @@ import io.github.agimaulana.radio.core.radioplayer.internal.RadioLibraryCatalog
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioSessionCallback
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @OptIn(UnstableApi::class)
@@ -29,11 +34,13 @@ class RadioService : MediaLibraryService() {
     private var mediaSession: MediaLibraryService.MediaLibrarySession? = null
     private lateinit var radioLibraryCatalog: RadioLibraryCatalog
     private lateinit var radioSessionCallback: RadioSessionCallback
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private var isLoadingNextPage = false
 
     override fun onCreate() {
         super.onCreate()
-        val player = createPlayer()
         radioLibraryCatalog = RadioLibraryCatalog(getRadioStationsUseCase, catalogStateRepository)
+        val player = createPlayer()
         radioSessionCallback = RadioSessionCallback(radioLibraryCatalog)
 
         mediaSession = MediaLibraryService.MediaLibrarySession.Builder(this, player, radioSessionCallback)
@@ -65,11 +72,12 @@ class RadioService : MediaLibraryService() {
         if (::radioSessionCallback.isInitialized) {
             radioSessionCallback.close()
         }
+        serviceScope.cancel()
         super.onDestroy()
     }
 
     private fun createPlayer(): ExoPlayer {
-        return ExoPlayer.Builder(this)
+        val player = ExoPlayer.Builder(this)
             .setLoadControl(DefaultLoadControl())
             .setLivePlaybackSpeedControl(DefaultLivePlaybackSpeedControl.Builder().build())
             .setAudioAttributes(
@@ -80,6 +88,37 @@ class RadioService : MediaLibraryService() {
                 true
             )
             .build()
+
+        player.addListener(object : Player.Listener {
+            override fun onMediaItemTransition(mediaItem: androidx.media3.common.MediaItem?, reason: Int) {
+                if (mediaItem == null) return
+                val currentIndex = player.currentMediaItemIndex
+                val playlistSize = player.mediaItemCount
+                if (!isLoadingNextPage && currentIndex >= playlistSize - 2 && playlistSize > 0) {
+                    serviceScope.launch {
+                        isLoadingNextPage = true
+                        try {
+                            val nextPage = (playlistSize / RadioLibraryCatalog.CATALOG_PAGE_SIZE)
+                            val newItems = radioLibraryCatalog.loadChildren(
+                                nextPage,
+                                RadioLibraryCatalog.CATALOG_PAGE_SIZE
+                            )
+                            if (newItems.isNotEmpty()) {
+                                val currentIds = (0 until player.mediaItemCount)
+                                    .map { player.getMediaItemAt(it).mediaId }.toSet()
+                                val filteredNewItems = newItems.filter { it.mediaId !in currentIds }
+                                if (filteredNewItems.isNotEmpty()) {
+                                    player.addMediaItems(filteredNewItems)
+                                }
+                            }
+                        } finally {
+                            isLoadingNextPage = false
+                        }
+                    }
+                }
+            }
+        })
+        return player
     }
 
     private fun createPendingMainActivityIntent(): PendingIntent {

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
@@ -14,6 +14,7 @@ import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import dagger.hilt.android.AndroidEntryPoint
+import io.github.agimaulana.radio.core.radioplayer.internal.PlaylistPaginator
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioLibraryCatalog
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioSessionCallback
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
@@ -37,7 +38,7 @@ class RadioService : MediaLibraryService() {
     private lateinit var radioLibraryCatalog: RadioLibraryCatalog
     private lateinit var radioSessionCallback: RadioSessionCallback
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    private var isLoadingNextPage = false
+    private var playlistPaginator: PlaylistPaginator? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -48,6 +49,8 @@ class RadioService : MediaLibraryService() {
         )
         val player = createPlayer()
         radioSessionCallback = RadioSessionCallback(radioLibraryCatalog)
+
+        playlistPaginator = PlaylistPaginator(player, radioLibraryCatalog, serviceScope)
 
         mediaSession = MediaLibraryService.MediaLibrarySession.Builder(this, player, radioSessionCallback)
             .setSessionActivity(createPendingMainActivityIntent())
@@ -70,6 +73,7 @@ class RadioService : MediaLibraryService() {
     }
 
     override fun onDestroy() {
+        playlistPaginator = null
         mediaSession?.run {
             player.release()
             release()
@@ -83,7 +87,7 @@ class RadioService : MediaLibraryService() {
     }
 
     private fun createPlayer(): ExoPlayer {
-        val player = ExoPlayer.Builder(this)
+        return ExoPlayer.Builder(this)
             .setLoadControl(DefaultLoadControl())
             .setLivePlaybackSpeedControl(DefaultLivePlaybackSpeedControl.Builder().build())
             .setAudioAttributes(
@@ -94,37 +98,6 @@ class RadioService : MediaLibraryService() {
                 true
             )
             .build()
-
-        player.addListener(object : Player.Listener {
-            override fun onMediaItemTransition(mediaItem: androidx.media3.common.MediaItem?, reason: Int) {
-                if (mediaItem == null) return
-                val currentIndex = player.currentMediaItemIndex
-                val playlistSize = player.mediaItemCount
-                if (!isLoadingNextPage && currentIndex >= playlistSize - 2 && playlistSize > 0) {
-                    isLoadingNextPage = true
-                    serviceScope.launch {
-                        try {
-                            val nextPage = (playlistSize / RadioLibraryCatalog.CATALOG_PAGE_SIZE)
-                            val newItems = radioLibraryCatalog.loadChildren(
-                                nextPage,
-                                RadioLibraryCatalog.CATALOG_PAGE_SIZE
-                            )
-                            if (newItems.isNotEmpty()) {
-                                val currentIds = (0 until player.mediaItemCount)
-                                    .map { player.getMediaItemAt(it).mediaId }.toSet()
-                                val filteredNewItems = newItems.filter { it.mediaId !in currentIds }
-                                if (filteredNewItems.isNotEmpty()) {
-                                    player.addMediaItems(filteredNewItems)
-                                }
-                            }
-                        } finally {
-                            isLoadingNextPage = false
-                        }
-                    }
-                }
-            }
-        })
-        return player
     }
 
     private fun createPendingMainActivityIntent(): PendingIntent {

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackEventFlow.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackEventFlow.kt
@@ -31,6 +31,10 @@ class PlaybackEventFlow(
         _event.trySend(PlaybackEvent.MediaItemTransition(mediaItem?.mediaId))
     }
 
+    override fun onTimelineChanged(timeline: androidx.media3.common.Timeline, reason: Int) {
+        _event.trySend(PlaybackEvent.PlaylistChanged)
+    }
+
     fun release() {
         mediaController.removeListener(this)
     }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaylistPaginator.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaylistPaginator.kt
@@ -1,0 +1,88 @@
+package io.github.agimaulana.radio.core.radioplayer.internal
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+internal class PlaylistPaginator(
+    private val player: Player,
+    private val catalog: RadioLibraryCatalog,
+    private val scope: CoroutineScope,
+) {
+    private var isLoading = false
+    private var lastLoadedPage = -1
+    private var hasMorePages = true
+
+    init {
+        player.addListener(object : Player.Listener {
+            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                checkPagination()
+            }
+        })
+    }
+
+    fun reset() {
+        lastLoadedPage = -1
+        hasMorePages = true
+        isLoading = false
+    }
+
+    private fun checkPagination() {
+        if (isLoading || !hasMorePages) return
+
+        val currentIndex = player.currentMediaItemIndex
+        val playlistSize = player.mediaItemCount
+
+        if (currentIndex >= playlistSize - 2 && playlistSize > 0) {
+            loadNextPage()
+        }
+    }
+
+    private fun loadNextPage() {
+        isLoading = true
+        scope.launch {
+            try {
+                // Explicit page tracking: determine next page from catalog state
+                val currentPage = catalog.getCurrentPage()
+                val nextPage = if (lastLoadedPage == -1) {
+                    // Initial pagination after fresh start or context switch
+                    maxOf(currentPage, player.mediaItemCount / RadioLibraryCatalog.CATALOG_PAGE_SIZE)
+                } else {
+                    lastLoadedPage + 1
+                }
+
+                if (nextPage <= lastLoadedPage) {
+                    Timber.d("Page %d already loaded, skipping", nextPage)
+                    return@launch
+                }
+
+                Timber.d("Loading next page: %d", nextPage)
+                val newItems = catalog.loadChildren(nextPage, RadioLibraryCatalog.CATALOG_PAGE_SIZE)
+                
+                if (newItems.isEmpty()) {
+                    hasMorePages = false
+                } else {
+                    lastLoadedPage = nextPage
+                    appendItems(newItems)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error loading next page")
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    private fun appendItems(newItems: List<MediaItem>) {
+        val currentIds = (0 until player.mediaItemCount).map { 
+            player.getMediaItemAt(it).mediaId 
+        }.toSet()
+        
+        val filtered = newItems.filter { it.mediaId !in currentIds }
+        if (filtered.isNotEmpty()) {
+            player.addMediaItems(filtered)
+        }
+    }
+}

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
@@ -11,6 +11,7 @@ import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import timber.log.Timber
 
 internal class RadioLibraryCatalog(
     private val getRadioStationsUseCase: GetRadioStationsUseCase,
@@ -106,6 +107,10 @@ internal class RadioLibraryCatalog(
         updateState { it.copy(page = it.page + 1) }
     }
 
+    suspend fun getCurrentPage(): Int {
+        return currentState().page
+    }
+
     suspend fun updateLocation(location: GeoLatLong?) {
         updateState {
             it.copy(
@@ -168,12 +173,17 @@ internal class RadioLibraryCatalog(
     }
 
     private fun RadioStation.toMediaItem(): MediaItem {
+        val streamUri = resolvedUrl.ifEmpty { url }
+        if (streamUri.isBlank()) {
+            Timber.tag("RadioLibraryCatalog").w("Radio station %s has no stream URL", name)
+        }
+
         return MediaItem.Builder()
             .setMediaId(stationUuid)
-            .setUri(resolvedUrl.ifEmpty { url })
+            .setUri(streamUri.takeIf { it.isNotBlank() }?.toUri())
             .setMediaMetadata(
                 MediaMetadata.Builder()
-                    .setIsPlayable(true)
+                    .setIsPlayable(streamUri.isNotBlank())
                     .setTitle(name)
                     .setSubtitle(tags.firstOrNull().orEmpty())
                     .setArtworkUri(imageUrl.takeIf { it.isNotBlank() }?.toUri())

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
@@ -59,10 +59,15 @@ internal class RadioLibraryCatalog(
         restore()
         if (mediaId == ROOT_MEDIA_ID) return rootItem()
 
-        val allChildren = cachedChildren ?: cacheMutex.withLock {
+        val allChildren = getPlaylist()
+        return allChildren.firstOrNull { it.mediaId == mediaId }
+    }
+
+    suspend fun getPlaylist(): List<MediaItem> {
+        restore()
+        return cachedChildren ?: cacheMutex.withLock {
             cachedChildren ?: loadAllChildren().also { cachedChildren = it }
         }
-        return allChildren.firstOrNull { it.mediaId == mediaId }
     }
 
     suspend fun restore() {
@@ -189,6 +194,6 @@ internal class RadioLibraryCatalog(
 
     companion object {
         internal const val ROOT_MEDIA_ID = "root"
-        private const val CATALOG_PAGE_SIZE = 10
+        internal const val CATALOG_PAGE_SIZE = 10
     }
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
@@ -7,12 +7,14 @@ import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.CatalogState
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
+import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 internal class RadioLibraryCatalog(
     private val getRadioStationsUseCase: GetRadioStationsUseCase,
+    private val getRadioStationUseCase: GetRadioStationUseCase,
     private val catalogStateRepository: CatalogStateRepository,
 ) {
     @Volatile private var cachedChildren: List<MediaItem>? = null
@@ -60,13 +62,23 @@ internal class RadioLibraryCatalog(
         if (mediaId == ROOT_MEDIA_ID) return rootItem()
 
         val allChildren = getPlaylist()
-        return allChildren.firstOrNull { it.mediaId == mediaId }
+        val cached = allChildren.firstOrNull { it.mediaId == mediaId }
+
+        return cached ?: run {
+            try {
+                getRadioStationUseCase.execute(mediaId).toMediaItem()
+            } catch (_: NoSuchElementException) {
+                null
+            } catch (_: Exception) {
+                null
+            }
+        }
     }
 
     suspend fun getPlaylist(): List<MediaItem> {
         restore()
         return cachedChildren ?: cacheMutex.withLock {
-            cachedChildren ?: loadAllChildren().also { cachedChildren = it }
+            cachedChildren ?: loadInitialChildren().also { cachedChildren = it }
         }
     }
 
@@ -139,12 +151,12 @@ internal class RadioLibraryCatalog(
             previousState.source != updatedState.source
     }
 
-    private suspend fun loadAllChildren(): List<MediaItem> {
+    private suspend fun loadInitialChildren(): List<MediaItem> {
         val state = currentState()
         val stations = mutableListOf<RadioStation>()
         var nextPage = 1
 
-        while (true) {
+        while (nextPage <= MAX_INITIAL_PAGES) {
             val pageStations = loadStationsPage(nextPage, state)
             if (pageStations.isEmpty()) break
 
@@ -195,5 +207,6 @@ internal class RadioLibraryCatalog(
     companion object {
         internal const val ROOT_MEDIA_ID = "root"
         internal const val CATALOG_PAGE_SIZE = 10
+        private const val MAX_INITIAL_PAGES = 3
     }
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImpl.kt
@@ -5,6 +5,7 @@ import io.github.agimaulana.radio.core.radioplayer.PlaybackEvent
 import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.toMediaItem
+import io.github.agimaulana.radio.core.radioplayer.toRadioMediaItem
 import kotlinx.coroutines.flow.Flow
 
 internal class RadioPlayerControllerImpl(
@@ -68,6 +69,12 @@ internal class RadioPlayerControllerImpl(
             )
         }
         mediaController.addMediaItems(index, mediaItems)
+    }
+
+    override fun getPlaylist(): List<RadioMediaItem> {
+        return (0 until mediaController.mediaItemCount).map {
+            mediaController.getMediaItemAt(it).toRadioMediaItem()
+        }
     }
 
     override val mediaItemCount: Int

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
@@ -74,8 +74,13 @@ internal class RadioSessionCallback(
                     listOf(resolvedItem) to 0
                 }
             } else {
-                val resolvedItems = mediaItems.map { requested ->
-                    radioLibraryCatalog.findChild(requested.mediaId) ?: requested
+                val hasNoUri = mediaItems.any { it.localConfiguration == null }
+                val resolvedItems = if (hasNoUri) {
+                    mediaItems.map { requested ->
+                        radioLibraryCatalog.findChild(requested.mediaId) ?: requested
+                    }
+                } else {
+                    mediaItems
                 }
                 resolvedItems to startIndex
             }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
@@ -40,12 +40,8 @@ internal class RadioSessionCallback(
             .add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
             .build()
 
-        val availableSessionCommands = connectionResult.availableSessionCommands.buildUpon()
-            .add(PLAY_STATION_COMMAND)
-            .build()
-
         return MediaSession.ConnectionResult.accept(
-            availableSessionCommands,
+            connectionResult.availableSessionCommands,
             customPlayerCommands
         )
     }
@@ -65,11 +61,28 @@ internal class RadioSessionCallback(
             startPositionMs
         )
         return callbackScope.future {
-            MediaSession.MediaItemsWithStartPosition(
-                mediaItems.map { requested ->
+            val firstItem = mediaItems.firstOrNull()
+            val (playlist, resolvedIndex) = if (firstItem != null && mediaItems.size == 1) {
+                val catalogPlaylist = radioLibraryCatalog.getPlaylist()
+                val index = catalogPlaylist.indexOfFirst { it.mediaId == firstItem.mediaId }
+                if (index >= 0) {
+                    catalogPlaylist to index
+                } else {
+                    // Item not in catalog (could be a direct ID from an external source)
+                    // Try to find it and build a playlist around it or just use it as is
+                    val resolvedItem = radioLibraryCatalog.findChild(firstItem.mediaId) ?: firstItem
+                    listOf(resolvedItem) to 0
+                }
+            } else {
+                val resolvedItems = mediaItems.map { requested ->
                     radioLibraryCatalog.findChild(requested.mediaId) ?: requested
-                },
-                startIndex,
+                }
+                resolvedItems to startIndex
+            }
+
+            MediaSession.MediaItemsWithStartPosition(
+                playlist,
+                resolvedIndex,
                 startPositionMs
             )
         }
@@ -104,10 +117,7 @@ internal class RadioSessionCallback(
             customCommand.customAction
         )
 
-        return when (customCommand.customAction) {
-            ACTION_PLAY_STATION -> handlePlayStationCommand(session, args)
-            else -> Futures.immediateFuture(SessionResult(SessionResult.RESULT_ERROR_NOT_SUPPORTED))
-        }
+        return Futures.immediateFuture(SessionResult(SessionResult.RESULT_ERROR_NOT_SUPPORTED))
     }
 
     override fun onPlaybackResumption(
@@ -121,27 +131,24 @@ internal class RadioSessionCallback(
             isForPlayback
         )
 
-        val currentMediaItem = mediaSession.player.currentMediaItem
-        if (currentMediaItem != null) {
-            val startPositionMs = if (isForPlayback) mediaSession.player.currentPosition else C.TIME_UNSET
-            return Futures.immediateFuture(
-                MediaSession.MediaItemsWithStartPosition(
-                    listOf(currentMediaItem),
-                    C.INDEX_UNSET,
-                    startPositionMs
-                )
-            )
-        }
-
         return callbackScope.future {
-            val fallbackItem = radioLibraryCatalog.loadChildren(page = 0, pageSize = 1).firstOrNull()
-                ?: radioLibraryCatalog.rootItem()
-            val startPositionMs = if (isForPlayback) 0L else C.TIME_UNSET
-            MediaSession.MediaItemsWithStartPosition(
-                listOf(fallbackItem),
-                0,
-                startPositionMs
-            )
+            val playlist = radioLibraryCatalog.getPlaylist()
+            val currentMediaItem = mediaSession.player.currentMediaItem
+            val startPositionMs = if (isForPlayback) mediaSession.player.currentPosition else C.TIME_UNSET
+
+            val (items, index) = if (currentMediaItem != null) {
+                val foundIndex = playlist.indexOfFirst { it.mediaId == currentMediaItem.mediaId }
+                if (foundIndex >= 0) {
+                    playlist to foundIndex
+                } else {
+                    listOf(currentMediaItem) to C.INDEX_UNSET
+                }
+            } else {
+                val fallbackItem = playlist.firstOrNull() ?: radioLibraryCatalog.rootItem()
+                listOf(fallbackItem) to 0
+            }
+
+            MediaSession.MediaItemsWithStartPosition(items, index, startPositionMs)
         }
     }
 
@@ -196,43 +203,11 @@ internal class RadioSessionCallback(
         }
     }
 
-    private fun handlePlayStationCommand(
-        session: MediaSession,
-        args: Bundle
-    ): com.google.common.util.concurrent.ListenableFuture<SessionResult> {
-        val mediaId = args.getString(ARG_MEDIA_ID).orEmpty()
-        if (mediaId.isBlank()) {
-            return Futures.immediateFuture(SessionResult(SessionResult.RESULT_ERROR_BAD_VALUE))
-        }
-
-        return callbackScope.future {
-            val mediaItem = radioLibraryCatalog.findChild(mediaId)
-                ?: return@future SessionResult(SessionResult.RESULT_ERROR_BAD_VALUE)
-
-            val startPositionMs = args.getLong(ARG_START_POSITION_MS, 0L)
-            Timber.tag(TAG).d(
-                "play station mediaId=%s startPositionMs=%d",
-                mediaId,
-                startPositionMs
-            )
-
-            session.player.setMediaItem(mediaItem, startPositionMs)
-            session.player.prepare()
-            session.player.play()
-            SessionResult(SessionResult.RESULT_SUCCESS)
-        }
-    }
-
     fun close() {
         callbackScope.cancel()
     }
 
     private companion object {
         const val TAG = "RadioSessionCallback"
-        const val ACTION_PLAY_STATION = "io.github.agimaulana.radio.action.PLAY_STATION"
-        const val ARG_MEDIA_ID = "media_id"
-        const val ARG_START_POSITION_MS = "start_position_ms"
-
-        val PLAY_STATION_COMMAND = SessionCommand(ACTION_PLAY_STATION, Bundle.EMPTY)
     }
 }

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalogTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalogTest.kt
@@ -3,6 +3,7 @@ package io.github.agimaulana.radio.core.radioplayer.internal
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.CatalogState
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
+import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -18,11 +19,16 @@ import org.robolectric.RobolectricTestRunner
 class RadioLibraryCatalogTest {
 
     private val getRadioStationsUseCase = mockk<GetRadioStationsUseCase>()
+    private val getRadioStationUseCase = mockk<GetRadioStationUseCase>()
     private val catalogStateRepository = mockk<CatalogStateRepository>(relaxed = true)
 
     @Test
     fun rootItem_returnsBrowsableRoot() {
-        val catalog = RadioLibraryCatalog(getRadioStationsUseCase, catalogStateRepository)
+        val catalog = RadioLibraryCatalog(
+            getRadioStationsUseCase,
+            getRadioStationUseCase,
+            catalogStateRepository
+        )
 
         val root = catalog.rootItem()
 
@@ -47,7 +53,11 @@ class RadioLibraryCatalogTest {
             getRadioStationsUseCase.execute(page = 4, searchName = null, location = null)
         } returns emptyList()
 
-        val catalog = RadioLibraryCatalog(getRadioStationsUseCase, catalogStateRepository)
+        val catalog = RadioLibraryCatalog(
+            getRadioStationsUseCase,
+            getRadioStationUseCase,
+            catalogStateRepository
+        )
 
         val firstPage = catalog.loadChildren(page = 0, pageSize = 10)
         val secondPage = catalog.loadChildren(page = 1, pageSize = 10)
@@ -86,7 +96,11 @@ class RadioLibraryCatalogTest {
             getRadioStationsUseCase.execute(page = 2, searchName = null, location = null)
         } returns emptyList()
 
-        val catalog = RadioLibraryCatalog(getRadioStationsUseCase, catalogStateRepository)
+        val catalog = RadioLibraryCatalog(
+            getRadioStationsUseCase,
+            getRadioStationUseCase,
+            catalogStateRepository
+        )
 
         val children = catalog.loadChildren(page = 0, pageSize = 10)
 
@@ -110,7 +124,11 @@ class RadioLibraryCatalogTest {
             getRadioStationsUseCase.execute(page = 2, searchName = "jazz", location = null)
         } returns emptyList()
 
-        val catalog = RadioLibraryCatalog(getRadioStationsUseCase, catalogStateRepository)
+        val catalog = RadioLibraryCatalog(
+            getRadioStationsUseCase,
+            getRadioStationUseCase,
+            catalogStateRepository
+        )
 
         val children = catalog.loadChildren(page = 0, pageSize = 10)
 

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
@@ -1,6 +1,5 @@
 package io.github.agimaulana.radio.core.radioplayer.internal
 
-import android.os.Bundle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.session.MediaSession
@@ -26,8 +25,8 @@ class RadioSessionCallbackTest {
     private val player = mockk<Player>(relaxed = true)
 
     @Test
-    fun onSetMediaItems_resolvesRadioStationFromCatalog() = runTest {
-        val station = radioStation(
+    fun onSetMediaItems_resolvesRadioStationAndExpandsPlaylist() = runTest {
+        val station1 = radioStation(
             stationUuid = "station-1",
             name = "Station One",
             tags = listOf("news"),
@@ -35,28 +34,7 @@ class RadioSessionCallbackTest {
             url = "https://example.com/one",
             resolvedUrl = "https://stream.example.com/one"
         )
-        val callback = callbackForStations(listOf(station))
-        val controller = controller()
-        val session = session()
-
-        val result = callback.onSetMediaItems(
-            mediaSession = session,
-            controller = controller,
-            mediaItems = listOf(MediaItem.Builder().setMediaId("station-1").build()),
-            startIndex = 0,
-            startPositionMs = 1500L
-        ).get()
-
-        assertEquals(1, result.mediaItems.size)
-        assertEquals("station-1", result.mediaItems[0].mediaId)
-        assertEquals("https://stream.example.com/one", result.mediaItems[0].localConfiguration?.uri.toString())
-        assertEquals(0, result.startIndex)
-        assertEquals(1500L, result.startPositionMs)
-    }
-
-    @Test
-    fun onCustomCommand_playStation_setsPlayerAndStartsPlayback() = runTest {
-        val station = radioStation(
+        val station2 = radioStation(
             stationUuid = "station-2",
             name = "Station Two",
             tags = listOf("talk"),
@@ -64,30 +42,26 @@ class RadioSessionCallbackTest {
             url = "https://example.com/two",
             resolvedUrl = "https://stream.example.com/two"
         )
-        val callback = callbackForStations(listOf(station))
+        val callback = callbackForStations(listOf(station1, station2))
         val controller = controller()
         val session = session()
 
-        val result = callback.onCustomCommand(
-            session = session,
+        val result = callback.onSetMediaItems(
+            mediaSession = session,
             controller = controller,
-            customCommand = SessionCommand(
-                "io.github.agimaulana.radio.action.PLAY_STATION",
-                Bundle.EMPTY
-            ),
-            args = Bundle().apply {
-                putString("media_id", "station-2")
-                putLong("start_position_ms", 1234L)
-            }
+            mediaItems = listOf(MediaItem.Builder().setMediaId("station-2").build()),
+            startIndex = 0,
+            startPositionMs = 1500L
         ).get()
 
-        assertEquals(SessionResult.RESULT_SUCCESS, result.resultCode)
-        verifyOrder {
-            player.setMediaItem(match { it.mediaId == "station-2" }, 1234L)
-            player.prepare()
-            player.play()
-        }
+        assertEquals(2, result.mediaItems.size)
+        assertEquals("station-1", result.mediaItems[0].mediaId)
+        assertEquals("station-2", result.mediaItems[1].mediaId)
+        assertEquals("https://stream.example.com/two", result.mediaItems[1].localConfiguration?.uri.toString())
+        assertEquals(1, result.startIndex)
+        assertEquals(1500L, result.startPositionMs)
     }
+
 
     @Test
     fun onPlaybackResumption_returnsFirstCatalogItemWhenNothingIsPlaying() = runTest {

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
@@ -7,6 +7,7 @@ import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
+import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import io.mockk.coEvery
 import io.mockk.every
@@ -92,11 +93,18 @@ class RadioSessionCallbackTest {
 
     private fun callbackForStations(stations: List<RadioStation>): RadioSessionCallback {
         val useCase = mockk<GetRadioStationsUseCase>()
+        val getRadioStationUseCase = mockk<GetRadioStationUseCase>()
         val catalogStateRepository = mockk<CatalogStateRepository>(relaxed = true)
         coEvery { catalogStateRepository.load() } returns null
         coEvery { useCase.execute(page = 1, searchName = null, location = null) } returns stations
         coEvery { useCase.execute(page = 2, searchName = null, location = null) } returns emptyList()
-        return RadioSessionCallback(RadioLibraryCatalog(useCase, catalogStateRepository))
+        coEvery { getRadioStationUseCase.execute(any()) } answers {
+            val id = firstArg<String>()
+            stations.first { it.stationUuid == id }
+        }
+        return RadioSessionCallback(
+            RadioLibraryCatalog(useCase, getRadioStationUseCase, catalogStateRepository)
+        )
     }
 
     private fun controller(): MediaSession.ControllerInfo {

--- a/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/di/UseCaseModule.kt
+++ b/domain/impl/src/main/kotlin/io/github/agimaulana/radio/domain/impl/di/UseCaseModule.kt
@@ -3,7 +3,7 @@ package io.github.agimaulana.radio.domain.impl.di
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.components.SingletonComponent
 import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.PinStationUseCase
@@ -14,7 +14,7 @@ import io.github.agimaulana.radio.domain.impl.PinStationUseCaseImpl
 import io.github.agimaulana.radio.domain.impl.UnpinStationUseCaseImpl
 
 @Module
-@InstallIn(ViewModelComponent::class)
+@InstallIn(SingletonComponent::class)
 interface UseCaseModule {
 
     @Binds

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -453,8 +453,36 @@ class StationListViewModel @Inject constructor(
             }
 
             PlaybackEvent.PlaylistChanged -> {
-                // Handle playlist changes if needed, e.g., to sync with auto-pagination
-                // for now we can just rely on the existing list or refresh if necessary
+                syncWithPlayer()
+            }
+        }
+    }
+
+    private fun syncWithPlayer() {
+        val controller = radioPlayerController ?: return
+        val playerPlaylist = controller.getPlaylist()
+        val currentMediaId = controller.currentMediaId
+        val isPlaying = controller.isPlaying
+        val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
+
+        val syncedStations = playerPlaylist.map { item ->
+            item.toUiStateStation(
+                pinnedUuids = pinnedUuids,
+                currentMediaId = currentMediaId,
+                isPlaying = isPlaying
+            )
+        }.toPersistentList()
+
+        _uiState.update { state ->
+            // Only sync if the player actually has items, otherwise keep what we have
+            if (syncedStations.isNotEmpty()) {
+                state.copy(
+                    stations = syncedStations,
+                    // If player has more items than our PAGE_SIZE, we probably have more pages
+                    hasMorePages = syncedStations.size >= PAGE_SIZE
+                )
+            } else {
+                state
             }
         }
     }
@@ -563,6 +591,21 @@ private fun RadioStation.toUiStateStation(
     isBuffering = false,
     isPlaying = false,
     isPinned = stationUuid in pinnedUuids
+)
+
+private fun RadioMediaItem.toUiStateStation(
+    pinnedUuids: Set<String>,
+    currentMediaId: String?,
+    isPlaying: Boolean
+) = StationListViewModel.UiState.Station(
+    serverUuid = mediaId,
+    name = radioMetadata.stationName,
+    genre = radioMetadata.genre,
+    imageUrl = radioMetadata.imageUrl,
+    streamUrl = streamUrl,
+    isBuffering = false,
+    isPlaying = isPlaying && (mediaId == currentMediaId),
+    isPinned = mediaId in pinnedUuids
 )
 
 private fun StationListViewModel.UiState.Station.toRadioMediaItem() = RadioMediaItem(

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -14,6 +14,8 @@ import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.repository.CatalogState
+import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
 import io.github.agimaulana.radio.domain.api.repository.PinnedStationLimitReachedException
 import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
@@ -49,6 +51,7 @@ class StationListViewModel @Inject constructor(
     private val radioPlayerControllerFactory: RadioPlayerControllerFactory,
     private val stationListTracker: StationListTracker,
     private val locationProvider: LocationProvider,
+    private val catalogStateRepository: CatalogStateRepository,
     @ApplicationContext private val context: Context,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(UiState())
@@ -231,6 +234,14 @@ class StationListViewModel @Inject constructor(
             if (stationName.isNotBlank()) {
                 stationListTracker.trackSearchSubmitted(stationName)
             }
+            catalogStateRepository.save(
+                CatalogState(
+                    query = stationName,
+                    source = if (stationName.isNotBlank()) CatalogState.Source.SEARCH else CatalogState.Source.ALL,
+                    locationLat = _uiState.value.currentPosition?.latitude,
+                    locationLon = _uiState.value.currentPosition?.longitude
+                )
+            )
             fetchRadioStations(force = true)
         }
     }
@@ -324,6 +335,14 @@ class StationListViewModel @Inject constructor(
                     hasMorePages = true,
                 )
             }
+            catalogStateRepository.save(
+                CatalogState(
+                    query = _uiState.value.filterStationName,
+                    source = CatalogState.Source.LOCATION,
+                    locationLat = location.latitude,
+                    locationLon = location.longitude
+                )
+            )
             fetchRadioStations(force = true)
         }
     }
@@ -431,6 +450,11 @@ class StationListViewModel @Inject constructor(
                     _uiState.update { it.copy(selectedStation = uiStation) }
                     updatePlayerColors(uiStation.imageUrl)
                 }
+            }
+
+            PlaybackEvent.PlaylistChanged -> {
+                // Handle playlist changes if needed, e.g., to sync with auto-pagination
+                // for now we can just rely on the existing list or refresh if necessary
             }
         }
     }

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -461,29 +461,41 @@ class StationListViewModel @Inject constructor(
     private fun syncWithPlayer() {
         val controller = radioPlayerController ?: return
         val playerPlaylist = controller.getPlaylist()
+        if (playerPlaylist.isEmpty()) return
+
         val currentMediaId = controller.currentMediaId
         val isPlaying = controller.isPlaying
         val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
 
-        val syncedStations = playerPlaylist.map { item ->
-            item.toUiStateStation(
-                pinnedUuids = pinnedUuids,
-                currentMediaId = currentMediaId,
-                isPlaying = isPlaying
-            )
-        }.toPersistentList()
-
         _uiState.update { state ->
-            // Only sync if the player actually has items, otherwise keep what we have
-            if (syncedStations.isNotEmpty()) {
-                state.copy(
-                    stations = syncedStations,
-                    // If player has more items than our PAGE_SIZE, we probably have more pages
-                    hasMorePages = syncedStations.size >= PAGE_SIZE
-                )
+            val existingStations = state.stations
+            val firstPlayerId = playerPlaylist.first().mediaId
+            
+            val isAppend = existingStations.isNotEmpty() && 
+                          existingStations.any { it.serverUuid == firstPlayerId }
+
+            val updatedStations = if (isAppend) {
+                // If it's an append, we reconcile the lists to preserve existing objects if possible
+                playerPlaylist.map { playerItem ->
+                    val existing = existingStations.find { it.serverUuid == playerItem.mediaId }
+                    if (existing != null) {
+                        existing.copy(
+                            isPlaying = isPlaying && (existing.serverUuid == currentMediaId)
+                        )
+                    } else {
+                        playerItem.toUiStateStation(pinnedUuids, currentMediaId, isPlaying)
+                    }
+                }.toPersistentList()
             } else {
-                state
+                playerPlaylist.map { item ->
+                    item.toUiStateStation(pinnedUuids, currentMediaId, isPlaying)
+                }.toPersistentList()
             }
+
+            state.copy(
+                stations = updatedStations,
+                hasMorePages = updatedStations.size >= PAGE_SIZE
+            )
         }
     }
 

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__Fixtures.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__Fixtures.kt
@@ -8,6 +8,7 @@ import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
 import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
@@ -58,6 +59,9 @@ abstract class StationListViewModelTest__Fixtures {
     @RelaxedMockK
     protected lateinit var locationProvider: LocationProvider
 
+    @RelaxedMockK
+    protected lateinit var catalogStateRepository: CatalogStateRepository
+
     @MockK
     protected lateinit var context: Context
 
@@ -106,6 +110,7 @@ abstract class StationListViewModelTest__Fixtures {
             radioPlayerControllerFactory = radioPlayerControllerFactory,
             stationListTracker = stationListTracker,
             locationProvider = locationProvider,
+            catalogStateRepository = catalogStateRepository,
             context = context
         )
     }


### PR DESCRIPTION
This PR refactors the `RadioSessionCallback` to fully align with the standard Media3 control flow, addressing the 'hybrid' patterns identified in #46.

### Key Changes:
- **Enhanced `onSetMediaItems()`**: Now expands single item playback requests into a full catalog-driven playlist, providing proper context for external controllers (Android Auto, etc.).
- **Removed Custom Commands**: Eliminated `ACTION_PLAY_STATION` to ensure all playback goes through standard Media3 APIs.
- **Improved Resumption**: `onPlaybackResumption()` now restores the full queue context.
- **Dynamic Pagination**: Added a `Player.Listener` in `RadioService` to trigger background pagination as the user approaches the end of the current playlist.
- **Context Synchronization**: Updated `StationListViewModel` to sync its browsing context (search/location) with `CatalogStateRepository`, allowing the background player to expand the list using the user's active filters.

Closes #46