### PR TITLE
[codex] migrate radio to Media3 browsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Detekt — always append: --console=plain 2>&1 | grep -E '(detekt|e:|w:|error:|w
 
 ## Tech Stack
 
-- Kotlin 2.2.10, AGP 8.13.0, SDK 36
+- Kotlin 2.2.20, AGP 8.13.0, SDK 36
 - Jetpack Compose, Hilt DI, Media3
 - Detekt for linting
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A modern Android application for streaming radio stations, built with Jetpack Co
 
 ## 🛠 Tech Stack
 
-- **Language**: Kotlin 2.2.10
+- **Language**: Kotlin 2.2.20
 - **UI Framework**: Jetpack Compose
 - **Architecture**: Multi-module Clean Architecture + MVI/MVVM
 - **Dependency Injection**: Hilt

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Radio247Fm"
+        android:enableOnBackInvokedCallback="true"
         android:usesCleartextTraffic="true">
 
         <meta-data

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserController.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserController.kt
@@ -1,0 +1,21 @@
+package io.github.agimaulana.radio.core.radioplayer
+
+import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
+import kotlinx.coroutines.flow.StateFlow
+
+interface RadioBrowserController {
+    val pinnedStations: StateFlow<List<RadioMediaItem>>
+
+    suspend fun getPinned(): List<RadioMediaItem>
+
+    suspend fun getStation(mediaId: String): RadioMediaItem?
+
+    suspend fun getStations(
+        page: Int,
+        pageSize: Int,
+        searchName: String? = null,
+        location: GeoLatLong? = null,
+    ): List<RadioMediaItem>
+
+    fun release()
+}

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserController.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserController.kt
@@ -1,10 +1,10 @@
 package io.github.agimaulana.radio.core.radioplayer
 
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 
 interface RadioBrowserController {
-    val pinnedStations: StateFlow<List<RadioMediaItem>>
+    val pinnedStations: Flow<List<RadioMediaItem>>
 
     suspend fun getPinned(): List<RadioMediaItem>
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserFactory.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserFactory.kt
@@ -7,23 +7,38 @@ import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.MoreExecutors
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioBrowserControllerImpl
+import kotlinx.coroutines.suspendCancellableCoroutine
 import javax.inject.Inject
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
+import kotlin.coroutines.resumeWithException
 
 class RadioBrowserFactory @Inject constructor(
     @param:ApplicationContext private val context: Context,
 ) {
-    suspend fun get(): RadioBrowserController = suspendCoroutine { cont ->
+    suspend fun get(): RadioBrowserController = suspendCancellableCoroutine { cont ->
         val controller = RadioBrowserControllerImpl()
         val sessionToken = SessionToken(context, ComponentName(context, RadioService::class.java))
         val browserFuture = MediaBrowser.Builder(context, sessionToken)
             .setListener(controller.browserListener)
             .buildAsync()
 
+        cont.invokeOnCancellation {
+            browserFuture.cancel(true)
+        }
+
         browserFuture.addListener({
-            controller.attach(browserFuture.get())
-            cont.resume(controller)
+            runCatching {
+                browserFuture.get()
+            }.onSuccess { browser ->
+                controller.attach(browser)
+                if (cont.isActive) {
+                    cont.resume(controller)
+                }
+            }.onFailure { error ->
+                if (cont.isActive) {
+                    cont.resumeWithException(error)
+                }
+            }
         }, MoreExecutors.directExecutor())
     }
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserFactory.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserFactory.kt
@@ -6,14 +6,16 @@ import androidx.media3.session.MediaBrowser
 import androidx.media3.session.SessionToken
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioBrowserControllerImpl
+import io.github.agimaulana.radio.domain.api.repository.PinnedStationRepository
 import kotlinx.coroutines.guava.await
 import javax.inject.Inject
 
 class RadioBrowserFactory @Inject constructor(
     @param:ApplicationContext private val context: Context,
+    private val pinnedStationRepository: PinnedStationRepository,
 ) {
     suspend fun get(): RadioBrowserController {
-        val controller = RadioBrowserControllerImpl()
+        val controller = RadioBrowserControllerImpl(pinnedStationRepository.maxPins)
         val sessionToken = SessionToken(context, ComponentName(context, RadioService::class.java))
         val browser = MediaBrowser.Builder(context, sessionToken)
             .setListener(controller.browserListener)

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserFactory.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserFactory.kt
@@ -4,41 +4,23 @@ import android.content.ComponentName
 import android.content.Context
 import androidx.media3.session.MediaBrowser
 import androidx.media3.session.SessionToken
-import com.google.common.util.concurrent.MoreExecutors
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioBrowserControllerImpl
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.guava.await
 import javax.inject.Inject
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 class RadioBrowserFactory @Inject constructor(
     @param:ApplicationContext private val context: Context,
 ) {
-    suspend fun get(): RadioBrowserController = suspendCancellableCoroutine { cont ->
+    suspend fun get(): RadioBrowserController {
         val controller = RadioBrowserControllerImpl()
         val sessionToken = SessionToken(context, ComponentName(context, RadioService::class.java))
-        val browserFuture = MediaBrowser.Builder(context, sessionToken)
+        val browser = MediaBrowser.Builder(context, sessionToken)
             .setListener(controller.browserListener)
             .buildAsync()
+            .await()
 
-        cont.invokeOnCancellation {
-            browserFuture.cancel(true)
-        }
-
-        browserFuture.addListener({
-            runCatching {
-                browserFuture.get()
-            }.onSuccess { browser ->
-                controller.attach(browser)
-                if (cont.isActive) {
-                    cont.resume(controller)
-                }
-            }.onFailure { error ->
-                if (cont.isActive) {
-                    cont.resumeWithException(error)
-                }
-            }
-        }, MoreExecutors.directExecutor())
+        controller.attach(browser)
+        return controller
     }
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserFactory.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioBrowserFactory.kt
@@ -1,0 +1,29 @@
+package io.github.agimaulana.radio.core.radioplayer
+
+import android.content.ComponentName
+import android.content.Context
+import androidx.media3.session.MediaBrowser
+import androidx.media3.session.SessionToken
+import com.google.common.util.concurrent.MoreExecutors
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.github.agimaulana.radio.core.radioplayer.internal.RadioBrowserControllerImpl
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class RadioBrowserFactory @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) {
+    suspend fun get(): RadioBrowserController = suspendCoroutine { cont ->
+        val controller = RadioBrowserControllerImpl()
+        val sessionToken = SessionToken(context, ComponentName(context, RadioService::class.java))
+        val browserFuture = MediaBrowser.Builder(context, sessionToken)
+            .setListener(controller.browserListener)
+            .buildAsync()
+
+        browserFuture.addListener({
+            controller.attach(browserFuture.get())
+            cont.resume(controller)
+        }, MoreExecutors.directExecutor())
+    }
+}

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioLibraryContract.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioLibraryContract.kt
@@ -1,0 +1,11 @@
+package io.github.agimaulana.radio.core.radioplayer
+
+object RadioLibraryContract {
+    const val ROOT_MEDIA_ID = "root"
+    const val PINNED_MEDIA_ID = "pinned"
+    const val STATIONS_MEDIA_ID = "stations"
+
+    const val EXTRA_SEARCH = "io.github.agimaulana.radio.extra.SEARCH"
+    const val EXTRA_LOCATION_LAT = "io.github.agimaulana.radio.extra.LOCATION_LAT"
+    const val EXTRA_LOCATION_LON = "io.github.agimaulana.radio.extra.LOCATION_LON"
+}

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItem.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItem.kt
@@ -17,6 +17,8 @@ data class RadioMediaItem(
     )
 }
 
+private const val EXTRA_STREAM_URL = "radio_stream_url"
+
 internal fun RadioMediaItem.toMediaItem(
     contextType: String? = null,
     contextQuery: String? = null,
@@ -29,6 +31,7 @@ internal fun RadioMediaItem.toMediaItem(
 
     // Attach minimal playback context so the service can restore context after process death
     val extras = android.os.Bundle()
+    extras.putString(EXTRA_STREAM_URL, streamUrl)
     contextType?.let { extras.putString("playback_context_type", it) }
     contextQuery?.let { extras.putString("playback_context_query", it) }
     page?.let { extras.putInt("playback_context_page", it) }
@@ -39,14 +42,16 @@ internal fun RadioMediaItem.toMediaItem(
 
     return MediaItem.Builder()
         .setMediaId(mediaId)
-        .setUri(streamUrl)
+        .setUri(streamUrl.takeIf { it.isNotBlank() }?.toUri())
         .setMediaMetadata(metadataBuilder.build())
         .build()
 }
 
 fun MediaItem.toRadioMediaItem() = RadioMediaItem(
     mediaId = mediaId,
-    streamUrl = localConfiguration?.uri?.toString().orEmpty(),
+    streamUrl = localConfiguration?.uri?.toString().orEmpty().ifBlank {
+        mediaMetadata.extras?.getString(EXTRA_STREAM_URL).orEmpty()
+    },
     radioMetadata = RadioMediaItem.RadioMetadata(
         stationName = mediaMetadata.title?.toString().orEmpty(),
         genre = mediaMetadata.subtitle?.toString().orEmpty(),

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
@@ -14,6 +14,7 @@ import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import dagger.hilt.android.AndroidEntryPoint
+import io.github.agimaulana.radio.core.radioplayer.RadioLibraryContract.PINNED_MEDIA_ID
 import io.github.agimaulana.radio.core.radioplayer.internal.PlaylistPaginator
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioLibraryCatalog
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioSessionCallback
@@ -23,8 +24,10 @@ import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @OptIn(UnstableApi::class)
@@ -40,6 +43,7 @@ class RadioService : MediaLibraryService() {
     private lateinit var radioSessionCallback: RadioSessionCallback
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var playlistPaginator: PlaylistPaginator? = null
+    private var pinnedStationsJob: Job? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -58,6 +62,12 @@ class RadioService : MediaLibraryService() {
             .setSessionActivity(createPendingMainActivityIntent())
             .build()
         setMediaNotificationProvider(DefaultMediaNotificationProvider.Builder(this).build())
+
+        pinnedStationsJob = serviceScope.launch {
+            getPinnedStationsUseCase.execute().collect { pinnedStations ->
+                mediaSession?.notifyChildrenChanged(PINNED_MEDIA_ID, pinnedStations.size, null)
+            }
+        }
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? {
@@ -76,6 +86,7 @@ class RadioService : MediaLibraryService() {
 
     override fun onDestroy() {
         playlistPaginator = null
+        pinnedStationsJob?.cancel()
         mediaSession?.run {
             player.release()
             release()

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioService.kt
@@ -18,19 +18,20 @@ import io.github.agimaulana.radio.core.radioplayer.internal.PlaylistPaginator
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioLibraryCatalog
 import io.github.agimaulana.radio.core.radioplayer.internal.RadioSessionCallback
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
+import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @OptIn(UnstableApi::class)
 @AndroidEntryPoint
 class RadioService : MediaLibraryService() {
     @Inject lateinit var getRadioStationsUseCase: GetRadioStationsUseCase
+    @Inject lateinit var getPinnedStationsUseCase: GetPinnedStationsUseCase
     @Inject lateinit var getRadioStationUseCase: GetRadioStationUseCase
     @Inject lateinit var catalogStateRepository: CatalogStateRepository
 
@@ -44,6 +45,7 @@ class RadioService : MediaLibraryService() {
         super.onCreate()
         radioLibraryCatalog = RadioLibraryCatalog(
             getRadioStationsUseCase,
+            getPinnedStationsUseCase,
             getRadioStationUseCase,
             catalogStateRepository
         )
@@ -52,13 +54,13 @@ class RadioService : MediaLibraryService() {
 
         playlistPaginator = PlaylistPaginator(player, radioLibraryCatalog, serviceScope)
 
-        mediaSession = MediaLibraryService.MediaLibrarySession.Builder(this, player, radioSessionCallback)
+        mediaSession = MediaLibrarySession.Builder(this, player, radioSessionCallback)
             .setSessionActivity(createPendingMainActivityIntent())
             .build()
         setMediaNotificationProvider(DefaultMediaNotificationProvider.Builder(this).build())
     }
 
-    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibraryService.MediaLibrarySession? {
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? {
         return mediaSession
     }
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackEventFlow.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackEventFlow.kt
@@ -1,5 +1,6 @@
 package io.github.agimaulana.radio.core.radioplayer.internal
 
+import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
@@ -32,6 +33,7 @@ class PlaybackEventFlow(
     }
 
     override fun onTimelineChanged(timeline: androidx.media3.common.Timeline, reason: Int) {
+        Log.d("ketai", "Timeline changed: reason=$reason, timeline=$timeline")
         _event.trySend(PlaybackEvent.PlaylistChanged)
     }
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackEventFlow.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/PlaybackEventFlow.kt
@@ -1,6 +1,5 @@
 package io.github.agimaulana.radio.core.radioplayer.internal
 
-import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
@@ -33,7 +32,6 @@ class PlaybackEventFlow(
     }
 
     override fun onTimelineChanged(timeline: androidx.media3.common.Timeline, reason: Int) {
-        Log.d("ketai", "Timeline changed: reason=$reason, timeline=$timeline")
         _event.trySend(PlaybackEvent.PlaylistChanged)
     }
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -24,7 +24,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-internal class RadioBrowserControllerImpl : RadioBrowserController {
+internal class RadioBrowserControllerImpl(
+    private val pinnedStationLimit: Int,
+) : RadioBrowserController {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val pinnedInvalidations = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     private var browser: MediaBrowser? = null
@@ -79,7 +81,7 @@ internal class RadioBrowserControllerImpl : RadioBrowserController {
             val result = mediaBrowser.getChildren(
                 RadioLibraryContract.PINNED_MEDIA_ID,
                 0,
-                Int.MAX_VALUE,
+                pinnedStationLimit,
                 null
             ).await()
             result.value.orEmpty().map { it.toRadioMediaItem() }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -1,0 +1,142 @@
+package io.github.agimaulana.radio.core.radioplayer.internal
+
+import android.os.Bundle
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaBrowser
+import androidx.media3.session.MediaLibraryService
+import io.github.agimaulana.radio.core.radioplayer.RadioBrowserController
+import io.github.agimaulana.radio.core.radioplayer.RadioLibraryContract
+import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
+import io.github.agimaulana.radio.core.radioplayer.toRadioMediaItem
+import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.guava.await
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal class RadioBrowserControllerImpl : RadioBrowserController {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val _pinnedStations = MutableStateFlow<List<RadioMediaItem>>(emptyList())
+    private var browser: MediaBrowser? = null
+    private var pinnedSubscriptionJob: Job? = null
+
+    override val pinnedStations: StateFlow<List<RadioMediaItem>>
+        get() = _pinnedStations.asStateFlow()
+
+    val browserListener = object : MediaBrowser.Listener {
+        override fun onChildrenChanged(
+            browser: MediaBrowser,
+            parentId: String,
+            itemCount: Int,
+            params: MediaLibraryService.LibraryParams?
+        ) {
+            if (parentId == RadioLibraryContract.PINNED_MEDIA_ID) {
+                refreshPinnedStations()
+            }
+        }
+    }
+
+    fun attach(browser: MediaBrowser) {
+        this.browser = browser
+        pinnedSubscriptionJob?.cancel()
+        pinnedSubscriptionJob = scope.launch {
+            withContext(Dispatchers.Main.immediate) {
+                browser.subscribe(RadioLibraryContract.PINNED_MEDIA_ID, null).await()
+            }
+            refreshPinnedStations()
+        }
+    }
+
+    override suspend fun getPinned(): List<RadioMediaItem> {
+        val mediaBrowser = browser ?: return emptyList()
+        return withContext(Dispatchers.Main.immediate) {
+            val result = mediaBrowser.getChildren(
+                RadioLibraryContract.PINNED_MEDIA_ID,
+                0,
+                Int.MAX_VALUE,
+                null
+            ).await()
+            result.value.orEmpty().map { it.toRadioMediaItem() }
+        }
+    }
+
+    override suspend fun getStation(mediaId: String): RadioMediaItem? {
+        getPinned().firstOrNull { it.mediaId == mediaId }?.let { return it }
+
+        val mediaBrowser = browser ?: return null
+        return withContext(Dispatchers.Main.immediate) {
+            val result = mediaBrowser.getChildren(
+                RadioLibraryContract.STATIONS_MEDIA_ID,
+                0,
+                Int.MAX_VALUE,
+                null
+            ).await()
+            result.value.orEmpty()
+                .map { it.toRadioMediaItem() }
+                .firstOrNull { it.mediaId == mediaId }
+        }
+    }
+
+    @OptIn(UnstableApi::class)
+    override suspend fun getStations(
+        page: Int,
+        pageSize: Int,
+        searchName: String?,
+        location: GeoLatLong?,
+    ): List<RadioMediaItem> {
+        val mediaBrowser = browser ?: return emptyList()
+        val extras = Bundle().apply {
+            searchName?.takeIf { it.isNotBlank() }?.let {
+                putString(RadioLibraryContract.EXTRA_SEARCH, it)
+            }
+            location?.let {
+                putDouble(RadioLibraryContract.EXTRA_LOCATION_LAT, it.latitude)
+                putDouble(RadioLibraryContract.EXTRA_LOCATION_LON, it.longitude)
+            }
+        }
+        val params = if (extras.isEmpty) {
+            null
+        } else {
+            MediaLibraryService.LibraryParams.Builder()
+                .setExtras(extras)
+                .build()
+        }
+
+        return withContext(Dispatchers.Main.immediate) {
+            val result = mediaBrowser.getChildren(
+                RadioLibraryContract.STATIONS_MEDIA_ID,
+                page,
+                pageSize,
+                params
+            ).await()
+            result.value.orEmpty().map { it.toRadioMediaItem() }
+        }
+    }
+
+    override fun release() {
+        pinnedSubscriptionJob?.cancel()
+        browser?.unsubscribe(RadioLibraryContract.PINNED_MEDIA_ID)
+        browser?.release()
+        browser = null
+        scope.cancel()
+    }
+
+    private fun refreshPinnedStations() {
+        scope.launch {
+            runCatching {
+                getPinned()
+            }.onSuccess { pinned ->
+                _pinnedStations.value = pinned
+            }
+        }
+    }
+}

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -15,12 +15,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 internal class RadioBrowserControllerImpl : RadioBrowserController {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -29,9 +31,22 @@ internal class RadioBrowserControllerImpl : RadioBrowserController {
     private var pinnedSubscriptionJob: Job? = null
 
     override val pinnedStations: Flow<List<RadioMediaItem>> = flow {
-        emit(getPinned())
+        var lastPinned = emptyList<RadioMediaItem>()
+        lastPinned = runCatching { getPinned() }
+            .getOrElse { error ->
+                if (error is CancellationException) throw error
+                Timber.tag(TAG).w(error, "Failed to refresh pinned stations")
+                lastPinned
+            }
+        emit(lastPinned)
         pinnedInvalidations.collect {
-            emit(getPinned())
+            lastPinned = runCatching { getPinned() }
+                .getOrElse { error ->
+                    if (error is CancellationException) throw error
+                    Timber.tag(TAG).w(error, "Failed to refresh pinned stations")
+                    lastPinned
+                }
+            emit(lastPinned)
         }
     }
 
@@ -121,5 +136,9 @@ internal class RadioBrowserControllerImpl : RadioBrowserController {
         browser?.release()
         browser = null
         scope.cancel()
+    }
+
+    private companion object {
+        const val TAG = "RadioBrowserController"
     }
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -2,7 +2,6 @@ package io.github.agimaulana.radio.core.radioplayer.internal
 
 import android.os.Bundle
 import androidx.annotation.OptIn
-import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaBrowser
 import androidx.media3.session.MediaLibraryService
@@ -70,19 +69,10 @@ internal class RadioBrowserControllerImpl : RadioBrowserController {
     }
 
     override suspend fun getStation(mediaId: String): RadioMediaItem? {
-        getPinned().firstOrNull { it.mediaId == mediaId }?.let { return it }
-
         val mediaBrowser = browser ?: return null
         return withContext(Dispatchers.Main.immediate) {
-            val result = mediaBrowser.getChildren(
-                RadioLibraryContract.STATIONS_MEDIA_ID,
-                0,
-                Int.MAX_VALUE,
-                null
-            ).await()
-            result.value.orEmpty()
-                .map { it.toRadioMediaItem() }
-                .firstOrNull { it.mediaId == mediaId }
+            val result = mediaBrowser.getItem(mediaId).await()
+            result.value?.toRadioMediaItem()
         }
     }
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -15,21 +15,25 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 internal class RadioBrowserControllerImpl : RadioBrowserController {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val _pinnedStations = MutableStateFlow<List<RadioMediaItem>>(emptyList())
+    private val pinnedInvalidations = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     private var browser: MediaBrowser? = null
     private var pinnedSubscriptionJob: Job? = null
 
-    override val pinnedStations: StateFlow<List<RadioMediaItem>>
-        get() = _pinnedStations.asStateFlow()
+    override val pinnedStations: Flow<List<RadioMediaItem>> = flow {
+        emit(getPinned())
+        pinnedInvalidations.collect {
+            emit(getPinned())
+        }
+    }
 
     val browserListener = object : MediaBrowser.Listener {
         override fun onChildrenChanged(
@@ -39,7 +43,7 @@ internal class RadioBrowserControllerImpl : RadioBrowserController {
             params: MediaLibraryService.LibraryParams?
         ) {
             if (parentId == RadioLibraryContract.PINNED_MEDIA_ID) {
-                refreshPinnedStations()
+                pinnedInvalidations.tryEmit(Unit)
             }
         }
     }
@@ -51,7 +55,6 @@ internal class RadioBrowserControllerImpl : RadioBrowserController {
             withContext(Dispatchers.Main.immediate) {
                 browser.subscribe(RadioLibraryContract.PINNED_MEDIA_ID, null).await()
             }
-            refreshPinnedStations()
         }
     }
 
@@ -118,15 +121,5 @@ internal class RadioBrowserControllerImpl : RadioBrowserController {
         browser?.release()
         browser = null
         scope.cancel()
-    }
-
-    private fun refreshPinnedStations() {
-        scope.launch {
-            runCatching {
-                getPinned()
-            }.onSuccess { pinned ->
-                _pinnedStations.value = pinned
-            }
-        }
     }
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
@@ -66,6 +66,21 @@ internal class RadioLibraryCatalog(
         search: String? = null,
         location: GeoLatLong? = null,
     ): List<MediaItem> {
+        restore()
+        updateState {
+            it.copy(
+                query = search,
+                locationLat = location?.latitude,
+                locationLon = location?.longitude,
+                page = page,
+                source = when {
+                    location != null -> CatalogState.Source.LOCATION
+                    !search.isNullOrBlank() -> CatalogState.Source.SEARCH
+                    else -> CatalogState.Source.ALL
+                },
+            )
+        }
+
         if (pageSize <= 0) return emptyList()
 
         val startIndex = page * pageSize

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
@@ -7,14 +7,17 @@ import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.CatalogState
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
+import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.first
 import timber.log.Timber
 
 internal class RadioLibraryCatalog(
     private val getRadioStationsUseCase: GetRadioStationsUseCase,
+    private val getPinnedStationsUseCase: GetPinnedStationsUseCase,
     private val getRadioStationUseCase: GetRadioStationUseCase,
     private val catalogStateRepository: CatalogStateRepository,
 ) {
@@ -30,10 +33,58 @@ internal class RadioLibraryCatalog(
             .setMediaMetadata(
                 MediaMetadata.Builder()
                     .setIsBrowsable(true)
+                    .setIsPlayable(false)
                     .setTitle("Radio 24.7FM")
                     .build()
             )
             .build()
+    }
+
+    fun pinnedItem(): MediaItem {
+        return browsableCategoryItem(
+            mediaId = PINNED_MEDIA_ID,
+            title = "Pinned"
+        )
+    }
+
+    fun stationsItem(): MediaItem {
+        return browsableCategoryItem(
+            mediaId = STATIONS_MEDIA_ID,
+            title = "Stations"
+        )
+    }
+
+    suspend fun getPinned(): List<MediaItem> {
+        return getPinnedStationsUseCase.execute()
+            .first()
+            .map { it.toMediaItem() }
+    }
+
+    suspend fun getStations(
+        page: Int,
+        pageSize: Int,
+        search: String? = null,
+        location: GeoLatLong? = null,
+    ): List<MediaItem> {
+        if (pageSize <= 0) return emptyList()
+
+        val startIndex = page * pageSize
+        val firstCatalogPage = startIndex / CATALOG_PAGE_SIZE + 1
+        val lastCatalogPage = (startIndex + pageSize - 1) / CATALOG_PAGE_SIZE + 1
+        val stations = mutableListOf<RadioStation>()
+
+        for (catalogPage in firstCatalogPage..lastCatalogPage) {
+            val pageStations = loadStationsPage(
+                page = catalogPage,
+                search = search,
+                location = location
+            )
+            if (pageStations.isEmpty()) break
+            stations.addAll(pageStations)
+        }
+
+        val offsetInStations = startIndex - (firstCatalogPage - 1) * CATALOG_PAGE_SIZE
+        return stations.drop(offsetInStations).take(pageSize).map { it.toMediaItem() }
     }
 
     suspend fun loadChildren(page: Int, pageSize: Int): List<MediaItem> {
@@ -183,6 +234,7 @@ internal class RadioLibraryCatalog(
             .setUri(streamUri.takeIf { it.isNotBlank() }?.toUri())
             .setMediaMetadata(
                 MediaMetadata.Builder()
+                    .setIsBrowsable(false)
                     .setIsPlayable(streamUri.isNotBlank())
                     .setTitle(name)
                     .setSubtitle(tags.firstOrNull().orEmpty())
@@ -192,30 +244,60 @@ internal class RadioLibraryCatalog(
             .build()
     }
 
+    private suspend fun loadStationsPage(
+        page: Int,
+        search: String?,
+        location: GeoLatLong?,
+    ): List<RadioStation> {
+        return getRadioStationsUseCase.execute(
+            page = page,
+            searchName = search?.takeIf { it.isNotBlank() },
+            location = location
+        )
+    }
+
     private suspend fun loadStationsPage(page: Int, state: CatalogState): List<RadioStation> {
         return when (state.source) {
-            CatalogState.Source.ALL -> getRadioStationsUseCase.execute(
+            CatalogState.Source.ALL -> loadStationsPage(
                 page = page,
-                searchName = null,
+                search = null,
                 location = null
             )
 
-            CatalogState.Source.SEARCH -> getRadioStationsUseCase.execute(
+            CatalogState.Source.SEARCH -> loadStationsPage(
                 page = page,
-                searchName = state.query?.takeIf { it.isNotBlank() },
+                search = state.query,
                 location = null
             )
 
-            CatalogState.Source.LOCATION -> getRadioStationsUseCase.execute(
+            CatalogState.Source.LOCATION -> loadStationsPage(
                 page = page,
-                searchName = null,
+                search = null,
                 location = state.toLocation()
             )
         }
     }
 
+    private fun browsableCategoryItem(
+        mediaId: String,
+        title: String,
+    ): MediaItem {
+        return MediaItem.Builder()
+            .setMediaId(mediaId)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setIsBrowsable(true)
+                    .setIsPlayable(false)
+                    .setTitle(title)
+                    .build()
+            )
+            .build()
+    }
+
     companion object {
         internal const val ROOT_MEDIA_ID = "root"
+        internal const val PINNED_MEDIA_ID = "pinned"
+        internal const val STATIONS_MEDIA_ID = "stations"
         internal const val CATALOG_PAGE_SIZE = 10
         private const val MAX_INITIAL_PAGES = 3
     }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImpl.kt
@@ -34,6 +34,9 @@ internal class RadioPlayerControllerImpl(
         startIndex: Int,
         context: RadioPlayerController.PlaybackContext
     ) {
+        if (mediaController.mediaItemCount > 0) {
+            mediaController.stop()
+        }
         setMediaItems(items, startIndex, context)
         prepare()
         play()

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
@@ -12,8 +12,10 @@ import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
+import io.github.agimaulana.radio.core.radioplayer.RadioLibraryContract
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
+import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -198,13 +200,41 @@ internal class RadioSessionCallback(
         pageSize: Int,
         params: MediaLibraryService.LibraryParams?
     ): com.google.common.util.concurrent.ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
-        if (parentId != RadioLibraryCatalog.ROOT_MEDIA_ID) {
-            return Futures.immediateFuture(LibraryResult.ofItemList(emptyList(), params))
-        }
-
         return callbackScope.future {
-            val stations = radioLibraryCatalog.loadChildren(page, pageSize)
-            LibraryResult.ofItemList(stations, params)
+            val items = when (parentId) {
+                RadioLibraryContract.ROOT_MEDIA_ID -> listOf(
+                    radioLibraryCatalog.pinnedItem(),
+                    radioLibraryCatalog.stationsItem()
+                )
+
+                RadioLibraryContract.PINNED_MEDIA_ID -> radioLibraryCatalog.getPinned()
+
+                RadioLibraryContract.STATIONS_MEDIA_ID -> {
+                    radioLibraryCatalog.getStations(
+                        page = page,
+                        pageSize = pageSize,
+                        search = params?.extras?.getString(RadioLibraryContract.EXTRA_SEARCH)
+                            ?.takeIf { it.isNotBlank() },
+                        location = params?.extras?.let { extras ->
+                            if (
+                                extras.containsKey(RadioLibraryContract.EXTRA_LOCATION_LAT) &&
+                                extras.containsKey(RadioLibraryContract.EXTRA_LOCATION_LON)
+                            ) {
+                                GeoLatLong(
+                                    latitude = extras.getDouble(RadioLibraryContract.EXTRA_LOCATION_LAT),
+                                    longitude = extras.getDouble(RadioLibraryContract.EXTRA_LOCATION_LON)
+                                )
+                            } else {
+                                null
+                            }
+                        }
+                    )
+                }
+
+                else -> emptyList()
+            }
+
+            LibraryResult.ofItemList(items, params)
         }
     }
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
@@ -12,9 +12,9 @@ import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
-import io.github.agimaulana.radio.core.radioplayer.RadioLibraryContract
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
+import io.github.agimaulana.radio.core.radioplayer.RadioLibraryContract
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -190,6 +190,18 @@ internal class RadioSessionCallback(
         params: MediaLibraryService.LibraryParams?
     ): com.google.common.util.concurrent.ListenableFuture<LibraryResult<MediaItem>> {
         return Futures.immediateFuture(LibraryResult.ofItem(radioLibraryCatalog.rootItem(), params))
+    }
+
+    override fun onGetItem(
+        session: MediaLibraryService.MediaLibrarySession,
+        browser: MediaSession.ControllerInfo,
+        mediaId: String
+    ): com.google.common.util.concurrent.ListenableFuture<LibraryResult<MediaItem>> {
+        return callbackScope.future {
+            radioLibraryCatalog.findChild(mediaId)?.let { item ->
+                LibraryResult.ofItem(item, null)
+            } ?: LibraryResult.ofError(LibraryResult.RESULT_ERROR_BAD_VALUE)
+        }
     }
 
     override fun onGetChildren(

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalogTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalogTest.kt
@@ -174,6 +174,7 @@ class RadioLibraryCatalogTest {
     @Test
     fun getStations_usesExplicitSearchAndLocation() = runTest {
         val location = io.github.agimaulana.radio.domain.api.entity.GeoLatLong(-6.2, 106.8)
+        coEvery { catalogStateRepository.load() } returns null
         coEvery {
             getRadioStationsUseCase.execute(page = 1, searchName = "jazz", location = location)
         } returns buildStations(1, 10)
@@ -198,6 +199,15 @@ class RadioLibraryCatalogTest {
         assertEquals(10, stations.size)
         coVerify {
             getRadioStationsUseCase.execute(page = 1, searchName = "jazz", location = location)
+        }
+        coVerify {
+            catalogStateRepository.save(match {
+                it.query == "jazz" &&
+                    it.locationLat == location.latitude &&
+                    it.locationLon == location.longitude &&
+                    it.page == 0 &&
+                    it.source == CatalogState.Source.LOCATION
+            })
         }
     }
 

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalogTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalogTest.kt
@@ -3,10 +3,12 @@ package io.github.agimaulana.radio.core.radioplayer.internal
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.CatalogState
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
+import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -19,6 +21,7 @@ import org.robolectric.RobolectricTestRunner
 class RadioLibraryCatalogTest {
 
     private val getRadioStationsUseCase = mockk<GetRadioStationsUseCase>()
+    private val getPinnedStationsUseCase = mockk<GetPinnedStationsUseCase>()
     private val getRadioStationUseCase = mockk<GetRadioStationUseCase>()
     private val catalogStateRepository = mockk<CatalogStateRepository>(relaxed = true)
 
@@ -26,6 +29,7 @@ class RadioLibraryCatalogTest {
     fun rootItem_returnsBrowsableRoot() {
         val catalog = RadioLibraryCatalog(
             getRadioStationsUseCase,
+            getPinnedStationsUseCase,
             getRadioStationUseCase,
             catalogStateRepository
         )
@@ -55,6 +59,7 @@ class RadioLibraryCatalogTest {
 
         val catalog = RadioLibraryCatalog(
             getRadioStationsUseCase,
+            getPinnedStationsUseCase,
             getRadioStationUseCase,
             catalogStateRepository
         )
@@ -98,6 +103,7 @@ class RadioLibraryCatalogTest {
 
         val catalog = RadioLibraryCatalog(
             getRadioStationsUseCase,
+            getPinnedStationsUseCase,
             getRadioStationUseCase,
             catalogStateRepository
         )
@@ -126,6 +132,7 @@ class RadioLibraryCatalogTest {
 
         val catalog = RadioLibraryCatalog(
             getRadioStationsUseCase,
+            getPinnedStationsUseCase,
             getRadioStationUseCase,
             catalogStateRepository
         )
@@ -134,6 +141,64 @@ class RadioLibraryCatalogTest {
 
         assertEquals(10, children.size)
         coVerify { catalogStateRepository.save(match { it.page == 0 }) }
+    }
+
+    @Test
+    fun getPinned_returnsPinnedStations() = runTest {
+        every { getPinnedStationsUseCase.execute() } returns kotlinx.coroutines.flow.flowOf(
+            listOf(
+                RadioStation(
+                    stationUuid = "pinned-1",
+                    name = "Pinned 1",
+                    tags = listOf("Genre 1"),
+                    imageUrl = "https://example.com/pinned-1.png",
+                    url = "https://example.com/stream-pinned-1",
+                    resolvedUrl = "https://example.com/resolved-pinned-1"
+                )
+            )
+        )
+
+        val catalog = RadioLibraryCatalog(
+            getRadioStationsUseCase,
+            getPinnedStationsUseCase,
+            getRadioStationUseCase,
+            catalogStateRepository
+        )
+
+        val pinned = catalog.getPinned()
+
+        assertEquals(1, pinned.size)
+        assertEquals("pinned-1", pinned.first().mediaId)
+    }
+
+    @Test
+    fun getStations_usesExplicitSearchAndLocation() = runTest {
+        val location = io.github.agimaulana.radio.domain.api.entity.GeoLatLong(-6.2, 106.8)
+        coEvery {
+            getRadioStationsUseCase.execute(page = 1, searchName = "jazz", location = location)
+        } returns buildStations(1, 10)
+        coEvery {
+            getRadioStationsUseCase.execute(page = 2, searchName = "jazz", location = location)
+        } returns emptyList()
+
+        val catalog = RadioLibraryCatalog(
+            getRadioStationsUseCase,
+            getPinnedStationsUseCase,
+            getRadioStationUseCase,
+            catalogStateRepository
+        )
+
+        val stations = catalog.getStations(
+            page = 0,
+            pageSize = 10,
+            search = "jazz",
+            location = location
+        )
+
+        assertEquals(10, stations.size)
+        coVerify {
+            getRadioStationsUseCase.execute(page = 1, searchName = "jazz", location = location)
+        }
     }
 
     private fun buildStations(startIndex: Int, count: Int): List<RadioStation> {

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
@@ -2,11 +2,13 @@ package io.github.agimaulana.radio.core.radioplayer.internal
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
+import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import io.mockk.coEvery
@@ -91,11 +93,34 @@ class RadioSessionCallbackTest {
         assertEquals(0L, result.startPositionMs)
     }
 
+    @Test
+    fun onGetChildren_returnsRootCategories() = runTest {
+        val callback = callbackForStations(emptyList())
+        val controller = controller()
+        val session = librarySession()
+
+        val result = callback.onGetChildren(
+            session = session,
+            browser = controller,
+            parentId = RadioLibraryCatalog.ROOT_MEDIA_ID,
+            page = 0,
+            pageSize = 10,
+            params = null
+        ).get()
+
+        val items = requireNotNull(result.value)
+        assertEquals(2, items.size)
+        assertEquals(RadioLibraryCatalog.PINNED_MEDIA_ID, items[0].mediaId)
+        assertEquals(RadioLibraryCatalog.STATIONS_MEDIA_ID, items[1].mediaId)
+    }
+
     private fun callbackForStations(stations: List<RadioStation>): RadioSessionCallback {
         val useCase = mockk<GetRadioStationsUseCase>()
+        val getPinnedStationsUseCase = mockk<GetPinnedStationsUseCase>()
         val getRadioStationUseCase = mockk<GetRadioStationUseCase>()
         val catalogStateRepository = mockk<CatalogStateRepository>(relaxed = true)
         coEvery { catalogStateRepository.load() } returns null
+        every { getPinnedStationsUseCase.execute() } returns kotlinx.coroutines.flow.flowOf(emptyList())
         coEvery { useCase.execute(page = 1, searchName = null, location = null) } returns stations
         coEvery { useCase.execute(page = 2, searchName = null, location = null) } returns emptyList()
         coEvery { getRadioStationUseCase.execute(any()) } answers {
@@ -103,7 +128,12 @@ class RadioSessionCallbackTest {
             stations.first { it.stationUuid == id }
         }
         return RadioSessionCallback(
-            RadioLibraryCatalog(useCase, getRadioStationUseCase, catalogStateRepository)
+            RadioLibraryCatalog(
+                useCase,
+                getPinnedStationsUseCase,
+                getRadioStationUseCase,
+                catalogStateRepository
+            )
         )
     }
 
@@ -117,6 +147,12 @@ class RadioSessionCallbackTest {
         return mockk<MediaSession>(relaxed = true).also {
             every { it.player } returns player
             every { player.currentMediaItem } returns null
+        }
+    }
+
+    private fun librarySession(): MediaLibraryService.MediaLibrarySession {
+        return mockk<MediaLibraryService.MediaLibrarySession>(relaxed = true).also {
+            every { it.player } returns player
         }
     }
 

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
@@ -4,8 +4,6 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
-import androidx.media3.session.SessionCommand
-import androidx.media3.session.SessionResult
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
 import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
@@ -14,7 +12,6 @@ import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verifyOrder
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -112,6 +109,31 @@ class RadioSessionCallbackTest {
         assertEquals(2, items.size)
         assertEquals(RadioLibraryCatalog.PINNED_MEDIA_ID, items[0].mediaId)
         assertEquals(RadioLibraryCatalog.STATIONS_MEDIA_ID, items[1].mediaId)
+    }
+
+    @Test
+    fun onGetItem_returnsResolvedStation() = runTest {
+        val station = radioStation(
+            stationUuid = "station-4",
+            name = "Station Four",
+            tags = listOf("music"),
+            imageUrl = "https://example.com/four.png",
+            url = "https://example.com/four",
+            resolvedUrl = "https://stream.example.com/four"
+        )
+        val callback = callbackForStations(listOf(station))
+        val controller = controller()
+        val session = librarySession()
+
+        val result = callback.onGetItem(
+            session = session,
+            browser = controller,
+            mediaId = "station-4"
+        ).get()
+
+        val item = requireNotNull(result.value)
+        assertEquals("station-4", item.mediaId)
+        assertEquals("https://stream.example.com/four", item.localConfiguration?.uri.toString())
     }
 
     private fun callbackForStations(stations: List<RadioStation>): RadioSessionCallback {

--- a/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/repository/PinnedStationRepository.kt
+++ b/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/repository/PinnedStationRepository.kt
@@ -4,6 +4,7 @@ import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import kotlinx.coroutines.flow.Flow
 
 interface PinnedStationRepository {
+    val maxPins: Int
     fun getPinnedStations(): Flow<List<RadioStation>>
     suspend fun pinStation(station: RadioStation)
     suspend fun unpinStation(stationUuid: String)

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListScreen.kt
@@ -343,7 +343,9 @@ private fun StationListContent(
             listState = listState,
             onClick = { onAction(Action.Click(it)) },
             onLongClick = onLongClick,
-            onReachEnd = { onAction(Action.LoadMore) },
+            onViewportChanged = { totalItems, lastVisibleIndex ->
+                onAction(Action.LoadMore(totalItems, lastVisibleIndex))
+            },
             contentPadding = PaddingValues(
                 top = lerp(dims.expandedHeight, dims.collapsedHeight, dims.progress) + 16.dp,
                 bottom = innerPadding.calculateBottomPadding() + 80.dp,

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -58,6 +58,7 @@ class StationListViewModel @Inject constructor(
     private var searchJob: Job? = null
     private var fetchJob: Job? = null
     private var pinnedStationsJob: Job? = null
+    private var isStationsListNearEnd: Boolean? = null
 
     fun init(
         hasLocationPermission: Boolean = false,
@@ -119,9 +120,11 @@ class StationListViewModel @Inject constructor(
 
     fun onAction(action: Action) {
         when (action) {
-            Action.LoadMore -> {
-                stationListTracker.trackLoadMore(page = _uiState.value.currentPage + 1)
-                fetchRadioStations()
+            is Action.LoadMore -> {
+                handleLoadMore(
+                    totalItems = action.totalItems,
+                    lastVisibleIndex = action.lastVisibleIndex
+                )
             }
 
             is Action.Search -> handleSearch(action.stationName)
@@ -217,6 +220,7 @@ class StationListViewModel @Inject constructor(
 
     private fun handleSearch(stationName: String) {
         searchJob?.cancel()
+        isStationsListNearEnd = null
         _uiState.update {
             it.copy(
                 filterStationName = stationName,
@@ -284,6 +288,7 @@ class StationListViewModel @Inject constructor(
             )
         }
         if (!isGranted) {
+            isStationsListNearEnd = null
             fetchRadioStations()
             return
         }
@@ -299,9 +304,11 @@ class StationListViewModel @Inject constructor(
 
             val location = locationProvider.getCurrentLocation()
             if (location == null) {
+                isStationsListNearEnd = null
                 fetchRadioStations()
                 return@launch
             }
+            isStationsListNearEnd = null
             _uiState.update {
                 it.copy(
                     locationName = listOf(location.adminArea, location.city)
@@ -324,6 +331,20 @@ class StationListViewModel @Inject constructor(
         if (isResolved) {
             handleLocationPermissionGranted(true)
         } else {
+            isStationsListNearEnd = null
+            fetchRadioStations()
+        }
+    }
+
+    private fun handleLoadMore(totalItems: Int, lastVisibleIndex: Int) {
+        if (totalItems <= 0) return
+
+        val isNearEnd = lastVisibleIndex >= totalItems - STATIONS_LIST_NEAR_END_THRESHOLD
+        val previousIsNearEnd = isStationsListNearEnd
+        isStationsListNearEnd = isNearEnd
+
+        if (isNearEnd && previousIsNearEnd == false) {
+            stationListTracker.trackLoadMore(page = _uiState.value.currentPage + 1)
             fetchRadioStations()
         }
     }
@@ -530,7 +551,10 @@ class StationListViewModel @Inject constructor(
     }
 
     sealed interface Action {
-        data object LoadMore : Action
+        data class LoadMore(
+            val totalItems: Int,
+            val lastVisibleIndex: Int
+        ) : Action
         data class Search(val stationName: String) : Action
         data class Click(val station: UiState.Station) : Action
         data class Play(val station: UiState.Station) : Action
@@ -552,6 +576,7 @@ class StationListViewModel @Inject constructor(
     companion object {
         internal const val SEARCH_DEBOUNCE_MS = 300L
         internal const val PAGE_SIZE = 10
+        private const val STATIONS_LIST_NEAR_END_THRESHOLD = 3
     }
 }
 
@@ -605,16 +630,6 @@ private fun StationListViewModel.UiState.Station.toRadioStation() = RadioStation
     imageUrl = imageUrl,
     url = streamUrl,
     resolvedUrl = streamUrl,
-)
-
-private fun RadioStation.toRadioMediaItem() = RadioMediaItem(
-    mediaId = stationUuid,
-    streamUrl = url,
-    radioMetadata = RadioMediaItem.RadioMetadata(
-        stationName = name,
-        genre = tags.getOrNull(0).orEmpty(),
-        imageUrl = imageUrl
-    )
 )
 
 private fun ImmutableList<StationListViewModel.UiState.Station>.togglePlayingStateForStations(

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -253,6 +253,15 @@ class StationListViewModel @Inject constructor(
                 stationName = station.name
             )
 
+            _uiState.update {
+                it.copy(
+                    selectedStation = station.copy(
+                        isBuffering = true,
+                        isPlaying = false
+                    )
+                )
+            }
+
             val main = _uiState.value.stations
             val startIndex = main.indexOfFirst { it.serverUuid == station.serverUuid }
 

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -387,6 +387,10 @@ class StationListViewModel @Inject constructor(
 
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
+            val browser = radioBrowser ?: run {
+                _uiState.update { it.copy(isStationsLoading = false) }
+                return@launch
+            }
             _uiState.update { it.copy(isStationsLoading = true) }
             try {
                 val nextPage = _uiState.value.currentPage + 1
@@ -394,7 +398,7 @@ class StationListViewModel @Inject constructor(
                 val searchName = _uiState.value.filterStationName
                 val location = _uiState.value.currentPosition
                 val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
-                val fetchedStations = radioBrowser?.getStations(
+                val fetchedStations = browser.getStations(
                     page = browserPage,
                     pageSize = PAGE_SIZE,
                     searchName = searchName,

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -9,17 +9,14 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.agimaulana.radio.core.radioplayer.PlaybackEvent
 import io.github.agimaulana.radio.core.radioplayer.PlaybackState
+import io.github.agimaulana.radio.core.radioplayer.RadioBrowserFactory
+import io.github.agimaulana.radio.core.radioplayer.RadioBrowserController
 import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
-import io.github.agimaulana.radio.domain.api.repository.CatalogState
-import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
 import io.github.agimaulana.radio.domain.api.repository.PinnedStationLimitReachedException
-import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
-import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
-import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.PinStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.UnpinStationUseCase
 import io.github.agimaulana.radio.feature.stationlist.location.LocationProvider
@@ -43,23 +40,21 @@ import javax.inject.Inject
 @Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class StationListViewModel @Inject constructor(
-    private val getRadioStationsUseCase: GetRadioStationsUseCase,
-    private val getRadioStationUseCase: GetRadioStationUseCase,
-    private val getPinnedStationsUseCase: GetPinnedStationsUseCase,
     private val pinStationUseCase: PinStationUseCase,
     private val unpinStationUseCase: UnpinStationUseCase,
     private val radioPlayerControllerFactory: RadioPlayerControllerFactory,
+    private val radioBrowserFactory: RadioBrowserFactory,
     private val stationListTracker: StationListTracker,
     private val locationProvider: LocationProvider,
-    private val catalogStateRepository: CatalogStateRepository,
     @ApplicationContext private val context: Context,
-) : ViewModel() {
+    ) : ViewModel() {
     private val _uiState = MutableStateFlow(UiState())
     val uiState = _uiState.asStateFlow()
     private val _uiEvent = MutableSharedFlow<UiEvent>()
     val uiEvent = _uiEvent.asSharedFlow()
 
     private var radioPlayerController: RadioPlayerController? = null
+    private var radioBrowser: RadioBrowserController? = null
     private var searchJob: Job? = null
     private var fetchJob: Job? = null
     private var pinnedStationsJob: Job? = null
@@ -75,24 +70,28 @@ class StationListViewModel @Inject constructor(
         )
         _uiState.update { it.copy(showLocationPermissionSheet = shouldShowSheet) }
         viewModelScope.launch {
-            radioPlayerController = radioPlayerControllerFactory.get().apply {
+            radioPlayerController = radioPlayerControllerFactory.get()
+            radioBrowser = radioBrowserFactory.get()
+            radioPlayerController?.apply {
                 viewModelScope.launch { event.collect(::onPlaybackEventReceived) }
             }
+            radioBrowser?.let(::observePinnedStations)
             restoreSelectedStation()
         }
-        observePinnedStations()
     }
 
-    private fun observePinnedStations() {
+    private fun observePinnedStations(browser: RadioBrowserController) {
         pinnedStationsJob?.cancel()
         pinnedStationsJob = viewModelScope.launch {
-            getPinnedStationsUseCase.execute().collect { pinned ->
-                val pinnedUuids = pinned.map { it.stationUuid }.toSet()
+            browser.pinnedStations.collect { browserPinned ->
+                val pinnedUuids = browserPinned.map { it.mediaId }.toSet()
+                val currentMediaId = radioPlayerController?.currentMediaId
+                val isPlaying = radioPlayerController?.isPlaying == true
                 _uiState.update { state ->
                     state.copy(
                         isPinnedStationsLoading = false,
-                        pinnedStations = pinned.map {
-                            it.toUiStateStation(pinnedUuids)
+                        pinnedStations = browserPinned.map {
+                            it.toUiStateStation(pinnedUuids, currentMediaId, isPlaying)
                         }.toImmutableList(),
                         stations = state.stations.map {
                             it.copy(isPinned = it.serverUuid in pinnedUuids)
@@ -106,9 +105,13 @@ class StationListViewModel @Inject constructor(
     private suspend fun restoreSelectedStation() {
         val mediaId = radioPlayerController?.currentMediaId ?: return
         if (mediaId.isNotEmpty()) {
-            val station = getRadioStationUseCase.execute(mediaId)
-            val uiStation = station.toUiStateStation(emptySet())
-                .copy(isPlaying = radioPlayerController?.isPlaying == true)
+            val browserStation = radioBrowser?.getStation(mediaId) ?: return
+            val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
+            val uiStation = browserStation.toUiStateStation(
+                pinnedUuids = pinnedUuids,
+                currentMediaId = mediaId,
+                isPlaying = radioPlayerController?.isPlaying == true
+            )
             _uiState.update { it.copy(selectedStation = uiStation) }
             updatePlayerColors(uiStation.imageUrl)
         }
@@ -204,8 +207,10 @@ class StationListViewModel @Inject constructor(
 
     private fun handlePinStation(station: UiState.Station) {
         viewModelScope.launch {
-            val domainStation = getRadioStationUseCase.execute(station.serverUuid) ?: return@launch
             try {
+                val domainStation = radioBrowser?.getStation(station.serverUuid)
+                    ?.toRadioStation()
+                    ?: station.toRadioStation()
                 pinStationUseCase.execute(domainStation)
             } catch (exception: PinnedStationLimitReachedException) {
                 _uiEvent.emit(UiEvent.ShowPinnedLimitReached(exception.maxPins))
@@ -234,14 +239,6 @@ class StationListViewModel @Inject constructor(
             if (stationName.isNotBlank()) {
                 stationListTracker.trackSearchSubmitted(stationName)
             }
-            catalogStateRepository.save(
-                CatalogState(
-                    query = stationName,
-                    source = if (stationName.isNotBlank()) CatalogState.Source.SEARCH else CatalogState.Source.ALL,
-                    locationLat = _uiState.value.currentPosition?.latitude,
-                    locationLon = _uiState.value.currentPosition?.longitude
-                )
-            )
             fetchRadioStations(force = true)
         }
     }
@@ -325,24 +322,16 @@ class StationListViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     locationName = listOf(location.adminArea, location.city)
-                        .filter { it.isNotEmpty() }
-                        .distinct()
-                        .joinToString(", ")
-                        .takeIf { it.isNotEmpty() },
-                    currentPosition = GeoLatLong(location.latitude, location.longitude),
+                    .filter { it.isNotEmpty() }
+                    .distinct()
+                    .joinToString(", ")
+                    .takeIf { it.isNotEmpty() },
+                currentPosition = GeoLatLong(location.latitude, location.longitude),
                     currentPage = 0,
                     stations = persistentListOf(),
                     hasMorePages = true,
                 )
             }
-            catalogStateRepository.save(
-                CatalogState(
-                    query = _uiState.value.filterStationName,
-                    source = CatalogState.Source.LOCATION,
-                    locationLat = location.latitude,
-                    locationLon = location.longitude
-                )
-            )
             fetchRadioStations(force = true)
         }
     }
@@ -388,15 +377,21 @@ class StationListViewModel @Inject constructor(
             _uiState.update { it.copy(isStationsLoading = true) }
             try {
                 val nextPage = _uiState.value.currentPage + 1
+                val browserPage = _uiState.value.currentPage
+                val searchName = _uiState.value.filterStationName
+                val location = _uiState.value.currentPosition
                 val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
-                val fetchedStations = getRadioStationsUseCase.execute(
-                    page = nextPage,
-                    searchName = _uiState.value.filterStationName,
-                    location = _uiState.value.currentPosition,
-                ).map {
-                    val isCurrentlyPlaying = (radioPlayerController?.currentMediaId == it.stationUuid)
-                        && (radioPlayerController?.isPlaying == true)
-                    it.toUiStateStation(pinnedUuids).copy(isPlaying = isCurrentlyPlaying)
+                val fetchedStations = radioBrowser?.getStations(
+                    page = browserPage,
+                    pageSize = PAGE_SIZE,
+                    searchName = searchName,
+                    location = location
+                ).orEmpty().map {
+                    it.toUiStateStation(
+                        pinnedUuids = pinnedUuids,
+                        currentMediaId = radioPlayerController?.currentMediaId,
+                        isPlaying = radioPlayerController?.isPlaying == true
+                    )
                 }.toPersistentList()
                 _uiState.update {
                     it.copy(
@@ -442,8 +437,12 @@ class StationListViewModel @Inject constructor(
             is PlaybackEvent.MediaItemTransition -> playbackEvent.mediaId?.let { mediaId ->
                 viewModelScope.launch {
                     val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
-                    val s = getRadioStationUseCase.execute(mediaId)
-                    val uiStation = s.toUiStateStation(pinnedUuids).copy(
+                    val browserStation = radioBrowser?.getStation(mediaId) ?: return@launch
+                    val uiStation = browserStation.toUiStateStation(
+                        pinnedUuids = pinnedUuids,
+                        currentMediaId = mediaId,
+                        isPlaying = radioPlayerController?.isPlaying == true
+                    ).copy(
                         isPlaying = radioPlayerController?.isPlaying == true,
                         isBuffering = station?.isBuffering ?: false
                     )
@@ -564,6 +563,7 @@ class StationListViewModel @Inject constructor(
         fetchJob?.cancel()
         pinnedStationsJob?.cancel()
         radioPlayerController?.release()
+        radioBrowser?.release()
     }
 
     sealed interface Action {
@@ -624,6 +624,24 @@ private fun StationListViewModel.UiState.Station.toRadioMediaItem() = RadioMedia
     mediaId = serverUuid,
     streamUrl = streamUrl,
     radioMetadata = RadioMediaItem.RadioMetadata(name, genre, imageUrl)
+)
+
+private fun RadioMediaItem.toRadioStation() = RadioStation(
+    stationUuid = mediaId,
+    name = radioMetadata.stationName,
+    tags = listOf(radioMetadata.genre).filter { it.isNotBlank() },
+    imageUrl = radioMetadata.imageUrl,
+    url = streamUrl,
+    resolvedUrl = streamUrl,
+)
+
+private fun StationListViewModel.UiState.Station.toRadioStation() = RadioStation(
+    stationUuid = serverUuid,
+    name = name,
+    tags = listOf(genre).filter { it.isNotBlank() },
+    imageUrl = imageUrl,
+    url = streamUrl,
+    resolvedUrl = streamUrl,
 )
 
 private fun RadioStation.toRadioMediaItem() = RadioMediaItem(

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -9,8 +9,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.agimaulana.radio.core.radioplayer.PlaybackEvent
 import io.github.agimaulana.radio.core.radioplayer.PlaybackState
-import io.github.agimaulana.radio.core.radioplayer.RadioBrowserFactory
 import io.github.agimaulana.radio.core.radioplayer.RadioBrowserController
+import io.github.agimaulana.radio.core.radioplayer.RadioBrowserFactory
 import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
@@ -143,23 +143,14 @@ class StationListViewModel @Inject constructor(
                     // already loaded; just resume
                     radioPlayerController?.play()
                 } else {
-                    // Build playlist: if playing a pinned station, put pinned stations first then
-                    // remaining stations without duplicates
-                    val pinned = _uiState.value.pinnedStations
                     val main = _uiState.value.stations
-                    val combined = if (stationToPlay.isPinned) {
-                        val pinnedIds = pinned.map { it.serverUuid }.toSet()
-                        pinned + main.filterNot { it.serverUuid in pinnedIds }
-                    } else {
-                        main
-                    }
-                    val startIndex = combined.indexOfFirst {
+                    val startIndex = main.indexOfFirst {
                         it.serverUuid == stationToPlay.serverUuid
                     }
 
                     val context = _uiState.value.toPlaybackContext()
                     if (startIndex >= 0) {
-                        val playlist = combined.map { it.toRadioMediaItem() }
+                        val playlist = main.map { it.toRadioMediaItem() }
                         radioPlayerController?.apply {
                             startPlayback(
                                 items = playlist,
@@ -258,20 +249,12 @@ class StationListViewModel @Inject constructor(
                 stationName = station.name
             )
 
-            // Build playlist: if clicking a pinned station, put pinned stations first then remaining stations without duplicates
-            val pinned = _uiState.value.pinnedStations
             val main = _uiState.value.stations
-            val combined = if (station.isPinned) {
-                val pinnedIds = pinned.map { it.serverUuid }.toSet()
-                pinned + main.filterNot { it.serverUuid in pinnedIds }
-            } else {
-                main
-            }
-            val startIndex = combined.indexOfFirst { it.serverUuid == station.serverUuid }
+            val startIndex = main.indexOfFirst { it.serverUuid == station.serverUuid }
 
             val context = uiState.value.toPlaybackContext()
             if (startIndex >= 0) {
-                val playlist = combined.map { it.toRadioMediaItem() }
+                val playlist = main.map { it.toRadioMediaItem() }
                 radioPlayerController?.apply {
                     startPlayback(
                         items = playlist,
@@ -459,41 +442,21 @@ class StationListViewModel @Inject constructor(
 
     private fun syncWithPlayer() {
         val controller = radioPlayerController ?: return
-        val playerPlaylist = controller.getPlaylist()
-        if (playerPlaylist.isEmpty()) return
+        if (controller.getPlaylist().isEmpty()) return
 
         val currentMediaId = controller.currentMediaId
         val isPlaying = controller.isPlaying
-        val pinnedUuids = _uiState.value.pinnedStations.map { it.serverUuid }.toSet()
 
         _uiState.update { state ->
-            val existingStations = state.stations
-            val firstPlayerId = playerPlaylist.first().mediaId
-            
-            val isAppend = existingStations.isNotEmpty() && 
-                          existingStations.any { it.serverUuid == firstPlayerId }
-
-            val updatedStations = if (isAppend) {
-                // If it's an append, we reconcile the lists to preserve existing objects if possible
-                playerPlaylist.map { playerItem ->
-                    val existing = existingStations.find { it.serverUuid == playerItem.mediaId }
-                    if (existing != null) {
-                        existing.copy(
-                            isPlaying = isPlaying && (existing.serverUuid == currentMediaId)
-                        )
-                    } else {
-                        playerItem.toUiStateStation(pinnedUuids, currentMediaId, isPlaying)
-                    }
-                }.toPersistentList()
-            } else {
-                playerPlaylist.map { item ->
-                    item.toUiStateStation(pinnedUuids, currentMediaId, isPlaying)
-                }.toPersistentList()
-            }
-
             state.copy(
-                stations = updatedStations,
-                hasMorePages = updatedStations.size >= PAGE_SIZE
+                stations = state.stations.togglePlayingStateForStations(
+                    targetUuid = currentMediaId.orEmpty(),
+                    isPlaying = isPlaying
+                ),
+                pinnedStations = state.pinnedStations.togglePlayingStateForStations(
+                    targetUuid = currentMediaId.orEmpty(),
+                    isPlaying = isPlaying
+                ).toImmutableList()
             )
         }
     }

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/component/LazyRadioStationList.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.agimaulana.radio.core.design.RadioTheme
 import io.github.agimaulana.radio.feature.stationlist.R
-import io.github.agimaulana.radio.feature.stationlist.player.BufferingIcon
 import io.github.agimaulana.radio.feature.stationlist.StationListViewModel.UiState.Station
+import io.github.agimaulana.radio.feature.stationlist.player.BufferingIcon
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -39,7 +39,7 @@ internal fun LazyRadioStationList(
     modifier: Modifier = Modifier,
     listState: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
-    onReachEnd: () -> Unit = {},
+    onViewportChanged: (totalItems: Int, lastVisibleIndex: Int) -> Unit = { _, _ -> },
 ) {
     val sectionLabelColor = contentColorFor(MaterialTheme.colorScheme.background).copy(alpha = 0.72f)
 
@@ -48,11 +48,9 @@ internal fun LazyRadioStationList(
             val layoutInfo = listState.layoutInfo
             val totalItems = layoutInfo.totalItemsCount
             val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-            lastVisibleIndex >= totalItems - 3 && totalItems > 0
-        }.collect {
-            if (it) {
-                onReachEnd()
-            }
+            totalItems to lastVisibleIndex
+        }.collect { (totalItems, lastVisibleIndex) ->
+            onViewportChanged(totalItems, lastVisibleIndex)
         }
     }
 

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
@@ -5,7 +5,6 @@ import app.cash.turbine.turbineScope
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController.PlaybackContext
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.domain.api.repository.PinnedStationLimitReachedException
-import io.github.agimaulana.radio.feature.stationlist.datafactories.newRadioStation
 import io.github.agimaulana.radio.feature.stationlist.datafactories.newUiStateStation
 import io.github.agimaulana.radio.feature.stationlist.location.LocationProvider
 import io.mockk.coEvery
@@ -122,8 +121,17 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
             )
             coEvery { locationProvider.getCurrentLocation() } returns locationInfo
             coEvery {
-                getRadioStationsUseCase.execute(page = 1, searchName = null, location = any())
+                radioBrowser.getStations(
+                    page = 0,
+                    pageSize = 10,
+                    searchName = null,
+                    location = GeoLatLong(-6.2, 106.8)
+                )
             } returns emptyList()
+
+            viewModel.init(hasLocationPermission = false, shouldShowRationale = false)
+            runCurrent()
+            uiState.awaitItem()
 
             viewModel.onAction(StationListViewModel.Action.OnLocationPermissionGranted(isGranted = true))
 
@@ -143,13 +151,7 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
                 assertFalse(isStationsLoading)
             }
 
-            coVerify {
-                getRadioStationsUseCase.execute(
-                    page = 1,
-                    searchName = null,
-                    location = GeoLatLong(-6.2, 106.8)
-                )
-            }
+            coVerify { radioBrowser.getStations(page = 0, pageSize = 10, searchName = null, location = GeoLatLong(-6.2, 106.8)) }
         }
     }
 
@@ -159,9 +161,11 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
             val uiState = viewModel.uiState.testIn(backgroundScope)
             uiState.awaitItem() // initial
 
-            coEvery {
-                getRadioStationsUseCase.execute(page = 1, searchName = null, location = null)
-            } returns emptyList()
+            coEvery { radioBrowser.getStations(page = 0, pageSize = 10, searchName = null, location = null) } returns emptyList()
+
+            viewModel.init(hasLocationPermission = false, shouldShowRationale = false)
+            runCurrent()
+            uiState.awaitItem()
 
             viewModel.onAction(StationListViewModel.Action.OnLocationPermissionGranted(isGranted = false))
 
@@ -176,9 +180,7 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
                 assertFalse(isStationsLoading)
             }
 
-            coVerify {
-                getRadioStationsUseCase.execute(page = 1, searchName = null, location = null)
-            }
+            coVerify { radioBrowser.getStations(page = 0, pageSize = 10, searchName = null, location = null) }
         }
     }
 
@@ -218,21 +220,17 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
     @Test
     fun `when pin station then execute use case`() = runTest {
         val station = newUiStateStation(withServerUuid = "uuid-1")
-        val domainStation = newRadioStation(withStationUuid = "uuid-1")
-        coEvery { getRadioStationUseCase.execute("uuid-1") } returns domainStation
 
         viewModel.onAction(StationListViewModel.Action.PinStation(station))
         runCurrent()
 
-        coVerify { pinStationUseCase.execute(domainStation) }
+        coVerify { pinStationUseCase.execute(station.toRadioStation()) }
     }
 
     @Test
     fun `when pin station reaches limit then emit snackbar event`() = runTest {
         val station = newUiStateStation(withServerUuid = "uuid-1")
-        val domainStation = newRadioStation(withStationUuid = "uuid-1")
-        coEvery { getRadioStationUseCase.execute("uuid-1") } returns domainStation
-        coEvery { pinStationUseCase.execute(domainStation) } throws PinnedStationLimitReachedException(maxPins = 8)
+        coEvery { pinStationUseCase.execute(station.toRadioStation()) } throws PinnedStationLimitReachedException(maxPins = 8)
 
         viewModel.uiEvent.test {
             viewModel.onAction(StationListViewModel.Action.PinStation(station))

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
@@ -270,6 +270,33 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
     }
 
     @Test
+    fun `given station is not playing when clicked then show buffering immediately`() = runTest {
+        turbineScope {
+            val station = newUiStateStation(
+                withServerUuid = "radio-1",
+                withName = "Radio 1"
+            )
+            every { radioPlayerController.currentMediaId } returns "radio-2"
+
+            val uiState = viewModel.uiState.testIn(backgroundScope)
+            uiState.awaitItem()
+
+            viewModel.init(hasLocationPermission = false, shouldShowRationale = false)
+            runCurrent()
+            uiState.expectMostRecentItem()
+
+            viewModel.onAction(StationListViewModel.Action.Click(station))
+
+            with(uiState.awaitItem()) {
+                assertEquals(
+                    station.copy(isBuffering = true),
+                    selectedStation
+                )
+            }
+        }
+    }
+
+    @Test
     fun `when pause then pause radio player`() {
         val station = newUiStateStation()
         viewModel.init(hasLocationPermission = false, shouldShowRationale = false)

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest.kt
@@ -185,6 +185,74 @@ class StationListViewModelTest : StationListViewModelTest__Fixtures() {
     }
 
     @Test
+    fun `given initial list near end when viewport changes then do not fetch until end transition`() = runTest {
+        turbineScope {
+            val uiState = viewModel.uiState.testIn(backgroundScope)
+            uiState.awaitItem() // initial
+
+            coEvery {
+                radioBrowser.getStations(
+                    page = 0,
+                    pageSize = 10,
+                    searchName = null,
+                    location = null
+                )
+            } returns emptyList()
+
+            viewModel.init(hasLocationPermission = false, shouldShowRationale = false)
+            runCurrent()
+            uiState.awaitItem()
+
+            viewModel.onAction(
+                StationListViewModel.Action.LoadMore(
+                    totalItems = 10,
+                    lastVisibleIndex = 9
+                )
+            )
+            runCurrent()
+
+            coVerify(exactly = 0) {
+                radioBrowser.getStations(
+                    page = 0,
+                    pageSize = 10,
+                    searchName = null,
+                    location = null
+                )
+            }
+
+            viewModel.onAction(
+                StationListViewModel.Action.LoadMore(
+                    totalItems = 10,
+                    lastVisibleIndex = 2
+                )
+            )
+            runCurrent()
+
+            viewModel.onAction(
+                StationListViewModel.Action.LoadMore(
+                    totalItems = 10,
+                    lastVisibleIndex = 9
+                )
+            )
+            runCurrent()
+
+            with(uiState.awaitItem()) {
+                assertEquals(1, currentPage)
+                assertFalse(isStationsLoading)
+            }
+
+            coVerify(exactly = 1) {
+                radioBrowser.getStations(
+                    page = 0,
+                    pageSize = 10,
+                    searchName = null,
+                    location = null
+                )
+            }
+        }
+    }
+
+    @Test
     fun `given station is not playing when clicked then set radio and play`() {
         val station = newUiStateStation(withServerUuid = "radio-1")
         every { radioPlayerController.currentMediaId } returns "radio-2"

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__Fixtures.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__Fixtures.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import io.github.agimaulana.radio.core.network.test.CoroutineMainDispatcherRule
 import io.github.agimaulana.radio.core.radioplayer.PlaybackEvent
-import io.github.agimaulana.radio.core.radioplayer.RadioBrowserFactory
 import io.github.agimaulana.radio.core.radioplayer.RadioBrowserController
+import io.github.agimaulana.radio.core.radioplayer.RadioBrowserFactory
 import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
@@ -21,7 +21,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.mockk
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.receiveAsFlow
 import org.junit.Before
 import org.junit.Rule
@@ -55,8 +55,6 @@ abstract class StationListViewModelTest__Fixtures {
 
     protected lateinit var playbackEventChannel: Channel<PlaybackEvent>
     protected lateinit var radioBrowser: RadioBrowserController
-    protected lateinit var pinnedStationsFlow: MutableStateFlow<List<RadioMediaItem>>
-
     protected lateinit var viewModel: StationListViewModel
 
     @get:Rule
@@ -79,10 +77,9 @@ abstract class StationListViewModelTest__Fixtures {
             radioPlayerControllerFactory.get()
         } returns radioPlayerController
         radioBrowser = mockk(relaxed = true)
-        pinnedStationsFlow = MutableStateFlow(emptyList())
         every {
             radioBrowser.pinnedStations
-        } returns pinnedStationsFlow
+        } returns flowOf(emptyList())
         coEvery {
             radioBrowser.getStation(any())
         } returns null

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__Fixtures.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__Fixtures.kt
@@ -4,17 +4,14 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import io.github.agimaulana.radio.core.network.test.CoroutineMainDispatcherRule
 import io.github.agimaulana.radio.core.radioplayer.PlaybackEvent
+import io.github.agimaulana.radio.core.radioplayer.RadioBrowserFactory
+import io.github.agimaulana.radio.core.radioplayer.RadioBrowserController
 import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerControllerFactory
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
-import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
-import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
-import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
-import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.PinStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.UnpinStationUseCase
-import io.github.agimaulana.radio.feature.stationlist.datafactories.newRadioStation
 import io.github.agimaulana.radio.feature.stationlist.datafactories.newUiStateStation
 import io.github.agimaulana.radio.feature.stationlist.location.LocationProvider
 import io.mockk.MockKAnnotations
@@ -24,7 +21,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.mockk
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import org.junit.Before
 import org.junit.Rule
@@ -33,16 +30,10 @@ import org.junit.Test
 abstract class StationListViewModelTest__Fixtures {
 
     @RelaxedMockK
-    protected lateinit var getRadioStationsUseCase: GetRadioStationsUseCase
-
-    @RelaxedMockK
     protected lateinit var radioPlayerControllerFactory: RadioPlayerControllerFactory
 
     @RelaxedMockK
-    protected lateinit var getRadioStationUseCase: GetRadioStationUseCase
-
-    @RelaxedMockK
-    protected lateinit var getPinnedStationsUseCase: GetPinnedStationsUseCase
+    protected lateinit var radioBrowserFactory: RadioBrowserFactory
 
     @RelaxedMockK
     protected lateinit var pinStationUseCase: PinStationUseCase
@@ -59,13 +50,12 @@ abstract class StationListViewModelTest__Fixtures {
     @RelaxedMockK
     protected lateinit var locationProvider: LocationProvider
 
-    @RelaxedMockK
-    protected lateinit var catalogStateRepository: CatalogStateRepository
-
     @MockK
     protected lateinit var context: Context
 
     protected lateinit var playbackEventChannel: Channel<PlaybackEvent>
+    protected lateinit var radioBrowser: RadioBrowserController
+    protected lateinit var pinnedStationsFlow: MutableStateFlow<List<RadioMediaItem>>
 
     protected lateinit var viewModel: StationListViewModel
 
@@ -88,29 +78,26 @@ abstract class StationListViewModelTest__Fixtures {
         coEvery {
             radioPlayerControllerFactory.get()
         } returns radioPlayerController
-        coEvery {
-            getRadioStationUseCase.execute(any())
-        } returns newRadioStation(
-            withStationUuid = "",
-            withName = "Test",
-        )
-        coEvery {
-            getRadioStationsUseCase.execute(page = 1, searchName = null, location = null)
-        } returns emptyList()
+        radioBrowser = mockk(relaxed = true)
+        pinnedStationsFlow = MutableStateFlow(emptyList())
         every {
-            getPinnedStationsUseCase.execute()
-        } returns flowOf(emptyList())
+            radioBrowser.pinnedStations
+        } returns pinnedStationsFlow
+        coEvery {
+            radioBrowser.getStation(any())
+        } returns null
+        coEvery {
+            radioBrowserFactory.get()
+        } returns radioBrowser
+        coEvery { radioBrowser.getStations(any(), any(), any(), any()) } returns emptyList<RadioMediaItem>()
 
         viewModel = StationListViewModel(
-            getRadioStationsUseCase = getRadioStationsUseCase,
-            getRadioStationUseCase = getRadioStationUseCase,
-            getPinnedStationsUseCase = getPinnedStationsUseCase,
             pinStationUseCase = pinStationUseCase,
             unpinStationUseCase = unpinStationUseCase,
             radioPlayerControllerFactory = radioPlayerControllerFactory,
+            radioBrowserFactory = radioBrowserFactory,
             stationListTracker = stationListTracker,
             locationProvider = locationProvider,
-            catalogStateRepository = catalogStateRepository,
             context = context
         )
     }
@@ -146,6 +133,17 @@ abstract class StationListViewModelTest__Fixtures {
                 genre = genre,
                 imageUrl = imageUrl,
             )
+        )
+    }
+
+    protected fun StationListViewModel.UiState.Station.toRadioStation(): RadioStation {
+        return RadioStation(
+            stationUuid = serverUuid,
+            name = name,
+            tags = listOf(genre).filter { it.isNotBlank() },
+            imageUrl = imageUrl,
+            url = streamUrl,
+            resolvedUrl = streamUrl,
         )
     }
 }

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__PlaybackEventFlow.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__PlaybackEventFlow.kt
@@ -19,8 +19,8 @@ class StationListViewModelTest__PlaybackEventFlow  : StationListViewModelTest__F
                 withName = "Radio 123",
             )
             coEvery {
-                getRadioStationUseCase.execute(station.stationUuid)
-            } returns station
+                radioBrowser.getStation(station.stationUuid)
+            } returns station.toUiStateStation().toRadioMediaItem()
             val uiState = viewModel.uiState.testIn(backgroundScope)
 
             viewModel.init(hasLocationPermission = false, hasAskedPermission = false, shouldShowRationale = false)

--- a/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__PlaybackEventFlow.kt
+++ b/feature/stationlist/src/test/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModelTest__PlaybackEventFlow.kt
@@ -4,9 +4,14 @@ import app.cash.turbine.turbineScope
 import io.github.agimaulana.radio.core.radioplayer.PlaybackEvent
 import io.github.agimaulana.radio.core.radioplayer.PlaybackState
 import io.github.agimaulana.radio.feature.stationlist.datafactories.newRadioStation
+import io.github.agimaulana.radio.feature.stationlist.datafactories.newUiStateStation
 import io.mockk.coEvery
+import io.mockk.every
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class StationListViewModelTest__PlaybackEventFlow  : StationListViewModelTest__Fixtures() {
@@ -62,6 +67,67 @@ class StationListViewModelTest__PlaybackEventFlow  : StationListViewModelTest__F
                 )
             }
             // region end: when playing state changed then update selected station
+        }
+    }
+
+    @Test
+    fun `when playlist changed then preserve station list shape`() = runTest {
+        turbineScope {
+            val uiStationOne = newUiStateStation(
+                withServerUuid = "radio-1",
+                withName = "Radio 1"
+            )
+            val uiStationTwo = newUiStateStation(
+                withServerUuid = "radio-2",
+                withName = "Radio 2"
+            )
+            coEvery {
+                radioBrowser.getStations(
+                    page = 0,
+                    pageSize = 10,
+                    searchName = null,
+                    location = null
+                )
+            } returns listOf(
+                uiStationOne.toRadioMediaItem(),
+                uiStationTwo.toRadioMediaItem()
+            )
+
+            var currentMediaId = ""
+            var isPlaying = false
+            every { radioPlayerController.currentMediaId } answers { currentMediaId }
+            every { radioPlayerController.isPlaying } answers { isPlaying }
+            every { radioPlayerController.getPlaylist() } returns listOf(
+                uiStationOne.toRadioMediaItem()
+            )
+
+            val uiState = viewModel.uiState.testIn(backgroundScope)
+
+            viewModel.init(
+                hasLocationPermission = false,
+                hasAskedPermission = false,
+                shouldShowRationale = false
+            )
+            viewModel.onAction(StationListViewModel.Action.OnLocationPermissionGranted(isGranted = false))
+            runCurrent()
+
+            with(uiState.expectMostRecentItem()) {
+                assertEquals(2, stations.size)
+                assertFalse(stations[0].isPlaying)
+                assertFalse(stations[1].isPlaying)
+            }
+
+            currentMediaId = "radio-1"
+            isPlaying = true
+            playbackEventChannel.send(PlaybackEvent.PlaylistChanged)
+            runCurrent()
+
+            with(uiState.awaitItem()) {
+                assertEquals(2, stations.size)
+                assertEquals("radio-1", stations[0].serverUuid)
+                assertTrue(stations[0].isPlaying)
+                assertFalse(stations[1].isPlaying)
+            }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ jdk = "VERSION_17"
 jdkNumber = "17"
 
 agp = "8.13.0"
-kotlin = "2.2.10"
+kotlin = "2.2.20"
 ksp = "2.2.20-2.0.3"
 androidDesugarJdkLibs = "2.1.5"
 androidMaterial = "1.13.0"

--- a/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/repository/PinnedStationRepositoryImpl.kt
+++ b/infrastructure/src/main/kotlin/io/github/agimaulana/radio/infrastructure/repository/PinnedStationRepositoryImpl.kt
@@ -34,6 +34,7 @@ class PinnedStationRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     moshi: Moshi
 ) : PinnedStationRepository {
+    override val maxPins: Int = MAX_PINS
     private val dataStore = context.pinnedStationsDataStore
 
     private val adapter = moshi.adapter<List<RadioStation>>(
@@ -59,8 +60,8 @@ class PinnedStationRepositoryImpl @Inject constructor(
             val current = decodePinnedStations(preferences[KEY_PINNED_STATIONS]).toMutableList()
             val isAlreadyPinned = current.any { it.stationUuid == station.stationUuid }
             if (isAlreadyPinned) return@edit
-            if (current.size >= MAX_PINS) {
-                throw PinnedStationLimitReachedException(MAX_PINS)
+            if (current.size >= maxPins) {
+                throw PinnedStationLimitReachedException(maxPins)
             }
             current.add(station)
             preferences[KEY_PINNED_STATIONS] = adapter.toJson(current)


### PR DESCRIPTION
## What changed
- Moved station browsing to `MediaLibraryService` as the source of truth.
- Added a browser controller wrapper so the ViewModel reads pinned and station data through `MediaBrowser`.
- Refactored the station list ViewModel to stop fetching stations directly from the domain use cases.
- Updated playback round-tripping so `RadioMediaItem` keeps stream URLs through Media3 metadata.
- Tightened the player source swap path to reduce codec shutdown warnings.
- Synced repository agent instructions and local GitNexus skill files.

## Why
This aligns the app with the target Media3 architecture:
- UI -> ViewModel -> MediaBrowser -> MediaLibraryService -> Catalog -> use cases
- single source of truth for browse/playback data
- Android Auto compatibility and consistent queue resolution

## Validation
- `./gradlew :core:radioplayer:compileDevDebugKotlin --console=plain`
- `./gradlew :core:radioplayer:testDevDebugUnitTest --tests "io.github.agimaulana.radio.core.radioplayer.internal.RadioPlayerControllerImplTest" --console=plain`
- `./gradlew :feature:stationlist:compileDevDebugKotlin --console=plain`
- `./gradlew :feature:stationlist:testDevDebugUnitTest --tests "io.github.agimaulana.radio.feature.stationlist.StationListViewModelTest" --tests "io.github.agimaulana.radio.feature.stationlist.StationListViewModelTest__PlaybackEventFlow" --console=plain`

## Notes
- GitNexus change detection flagged the staged diff as critical because this spans the radio playback and browse path.
- `gh` authentication is not usable in this environment, so I used the GitHub plugin path to publish the PR.

# Issue
Close https://github.com/AgiMaulana/Radio-24.7FM/issues/52