### PR TITLE
Fix pinned stations reactivity after MediaBrowser migration

### DIFF
--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -2,6 +2,7 @@ package io.github.agimaulana.radio.core.radioplayer.internal
 
 import android.os.Bundle
 import androidx.annotation.OptIn
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaBrowser
 import androidx.media3.session.MediaLibraryService
@@ -38,7 +39,7 @@ internal class RadioBrowserControllerImpl(
     override val pinnedStations: Flow<List<RadioMediaItem>> =
         _pinnedStations.asStateFlow()
 
-    val browserListener = object : MediaBrowser.Listener {
+    val browserListener = object : MediaBrowser.Listener, Player.Listener {
         override fun onChildrenChanged(
             browser: MediaBrowser,
             parentId: String,

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -2,7 +2,6 @@ package io.github.agimaulana.radio.core.radioplayer.internal
 
 import android.os.Bundle
 import androidx.annotation.OptIn
-import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaBrowser
 import androidx.media3.session.MediaLibraryService
@@ -39,9 +38,7 @@ internal class RadioBrowserControllerImpl(
     override val pinnedStations: Flow<List<RadioMediaItem>> =
         _pinnedStations.asStateFlow()
 
-    internal val browserListener = object :
-        Player.Listener,
-        MediaBrowser.Listener {
+    internal val browserListener = object : MediaBrowser.Listener {
         override fun onChildrenChanged(
             browser: MediaBrowser,
             parentId: String,
@@ -61,7 +58,6 @@ internal class RadioBrowserControllerImpl(
         pinnedSubscriptionJob?.cancel()
         pinnedSubscriptionJob = scope.launch {
             withContext(Dispatchers.Main.immediate) {
-                browser.addListener(browserListener as Player.Listener)
                 browser.subscribe(RadioLibraryContract.PINNED_MEDIA_ID, null).await()
             }
 
@@ -142,7 +138,6 @@ internal class RadioBrowserControllerImpl(
 
     override fun release() {
         pinnedSubscriptionJob?.cancel()
-        browser?.removeListener(browserListener as Player.Listener)
         browser?.unsubscribe(RadioLibraryContract.PINNED_MEDIA_ID)
         browser?.release()
         browser = null

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -10,15 +10,15 @@ import io.github.agimaulana.radio.core.radioplayer.RadioLibraryContract
 import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.toRadioMediaItem
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -28,29 +28,12 @@ internal class RadioBrowserControllerImpl(
     private val pinnedStationLimit: Int,
 ) : RadioBrowserController {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val pinnedInvalidations = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val _pinnedStations = MutableStateFlow<List<RadioMediaItem>>(emptyList())
     private var browser: MediaBrowser? = null
     private var pinnedSubscriptionJob: Job? = null
 
-    override val pinnedStations: Flow<List<RadioMediaItem>> = flow {
-        var lastPinned = emptyList<RadioMediaItem>()
-        lastPinned = runCatching { getPinned() }
-            .getOrElse { error ->
-                if (error is CancellationException) throw error
-                Timber.tag(TAG).w(error, "Failed to refresh pinned stations")
-                lastPinned
-            }
-        emit(lastPinned)
-        pinnedInvalidations.collect {
-            lastPinned = runCatching { getPinned() }
-                .getOrElse { error ->
-                    if (error is CancellationException) throw error
-                    Timber.tag(TAG).w(error, "Failed to refresh pinned stations")
-                    lastPinned
-                }
-            emit(lastPinned)
-        }
-    }
+    override val pinnedStations: Flow<List<RadioMediaItem>> =
+        _pinnedStations.asStateFlow()
 
     val browserListener = object : MediaBrowser.Listener {
         override fun onChildrenChanged(
@@ -60,7 +43,9 @@ internal class RadioBrowserControllerImpl(
             params: MediaLibraryService.LibraryParams?
         ) {
             if (parentId == RadioLibraryContract.PINNED_MEDIA_ID) {
-                pinnedInvalidations.tryEmit(Unit)
+                scope.launch {
+                    refreshPinned()
+                }
             }
         }
     }
@@ -72,6 +57,21 @@ internal class RadioBrowserControllerImpl(
             withContext(Dispatchers.Main.immediate) {
                 browser.subscribe(RadioLibraryContract.PINNED_MEDIA_ID, null).await()
             }
+
+            refreshPinned()
+        }
+    }
+
+    private suspend fun refreshPinned() {
+        val currentPinned = _pinnedStations.value
+
+        _pinnedStations.value = runCatching {
+            getPinned()
+        }.getOrElse { error ->
+            if (error is CancellationException) throw error
+
+            Timber.tag(TAG).w(error, "Failed to refresh pinned stations")
+            currentPinned
         }
     }
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -39,7 +39,7 @@ internal class RadioBrowserControllerImpl(
     override val pinnedStations: Flow<List<RadioMediaItem>> =
         _pinnedStations.asStateFlow()
 
-    private val browserListener: Player.Listener = object :
+    internal val browserListener = object :
         Player.Listener,
         MediaBrowser.Listener {
         override fun onChildrenChanged(
@@ -61,7 +61,7 @@ internal class RadioBrowserControllerImpl(
         pinnedSubscriptionJob?.cancel()
         pinnedSubscriptionJob = scope.launch {
             withContext(Dispatchers.Main.immediate) {
-                browser.addListener(browserListener)
+                browser.addListener(browserListener as Player.Listener)
                 browser.subscribe(RadioLibraryContract.PINNED_MEDIA_ID, null).await()
             }
 
@@ -142,7 +142,7 @@ internal class RadioBrowserControllerImpl(
 
     override fun release() {
         pinnedSubscriptionJob?.cancel()
-        browser?.removeListener(browserListener)
+        browser?.removeListener(browserListener as Player.Listener)
         browser?.unsubscribe(RadioLibraryContract.PINNED_MEDIA_ID)
         browser?.release()
         browser = null

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -39,7 +39,9 @@ internal class RadioBrowserControllerImpl(
     override val pinnedStations: Flow<List<RadioMediaItem>> =
         _pinnedStations.asStateFlow()
 
-    val browserListener = object : MediaBrowser.Listener, Player.Listener {
+    private val browserListener: Player.Listener = object :
+        Player.Listener,
+        MediaBrowser.Listener {
         override fun onChildrenChanged(
             browser: MediaBrowser,
             parentId: String,

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioBrowserControllerImpl.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -28,6 +30,7 @@ internal class RadioBrowserControllerImpl(
     private val pinnedStationLimit: Int,
 ) : RadioBrowserController {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val refreshPinnedMutex = Mutex()
     private val _pinnedStations = MutableStateFlow<List<RadioMediaItem>>(emptyList())
     private var browser: MediaBrowser? = null
     private var pinnedSubscriptionJob: Job? = null
@@ -55,6 +58,7 @@ internal class RadioBrowserControllerImpl(
         pinnedSubscriptionJob?.cancel()
         pinnedSubscriptionJob = scope.launch {
             withContext(Dispatchers.Main.immediate) {
+                browser.addListener(browserListener)
                 browser.subscribe(RadioLibraryContract.PINNED_MEDIA_ID, null).await()
             }
 
@@ -63,15 +67,16 @@ internal class RadioBrowserControllerImpl(
     }
 
     private suspend fun refreshPinned() {
-        val currentPinned = _pinnedStations.value
+        refreshPinnedMutex.withLock {
+            runCatching {
+                getPinned()
+            }.onSuccess {
+                _pinnedStations.value = it
+            }.onFailure { error ->
+                if (error is CancellationException) throw error
 
-        _pinnedStations.value = runCatching {
-            getPinned()
-        }.getOrElse { error ->
-            if (error is CancellationException) throw error
-
-            Timber.tag(TAG).w(error, "Failed to refresh pinned stations")
-            currentPinned
+                Timber.tag(TAG).w(error, "Failed to refresh pinned stations")
+            }
         }
     }
 
@@ -134,6 +139,7 @@ internal class RadioBrowserControllerImpl(
 
     override fun release() {
         pinnedSubscriptionJob?.cancel()
+        browser?.removeListener(browserListener)
         browser?.unsubscribe(RadioLibraryContract.PINNED_MEDIA_ID)
         browser?.release()
         browser = null


### PR DESCRIPTION
## Summary

Fixes the pinned stations stale UI issue introduced after the MediaBrowser migration.

This PR replaces the transient invalidation-based architecture:

```text
SharedFlow<Unit>
 -> manual refresh flow
```

with a persistent state-based architecture:

```text
MutableStateFlow<List<RadioMediaItem>>
```

## Changes

- removed `MutableSharedFlow<Unit>` invalidation pipeline
- removed custom cold `flow {}` builder
- introduced `_pinnedStations: MutableStateFlow<List<RadioMediaItem>>`
- added `refreshPinned()` helper
- `onChildrenChanged()` now refreshes state directly
- initial attach now immediately refreshes pinned state

Fixes #57