### PR TITLE
feat: introduce explicit PlaybackContext for Media3 playback

### DIFF
--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItem.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItem.kt
@@ -17,24 +17,41 @@ data class RadioMediaItem(
     )
 }
 
-private const val EXTRA_STREAM_URL = "radio_stream_url"
+object PlaybackExtras {
+    const val KEY_STREAM_URL = "radio_stream_url"
+    const val KEY_CONTEXT_TYPE = "playback_context_type"
+    const val KEY_CONTEXT_QUERY = "playback_context_query"
+    const val KEY_CONTEXT_PAGE = "playback_context_page"
+    const val KEY_CONTEXT_LAT = "playback_context_lat"
+    const val KEY_CONTEXT_LON = "playback_context_lon"
+
+    const val TYPE_PINNED = "PINNED"
+    const val TYPE_SEARCH = "SEARCH"
+    const val TYPE_ALL = "ALL"
+    const val TYPE_LOCATION = "LOCATION"
+}
+
+private const val EXTRA_STREAM_URL = PlaybackExtras.KEY_STREAM_URL
 
 internal fun RadioMediaItem.toMediaItem(
     contextType: String? = null,
     contextQuery: String? = null,
-    page: Int? = null
+    page: Int? = null,
+    contextLat: Double? = null,
+    contextLon: Double? = null,
 ): MediaItem {
     val metadataBuilder = MediaMetadata.Builder()
         .setTitle(radioMetadata.stationName)
         .setSubtitle(radioMetadata.genre)
         .setArtworkUri(radioMetadata.imageUrl.toUri())
 
-    // Attach minimal playback context so the service can restore context after process death
     val extras = android.os.Bundle()
     extras.putString(EXTRA_STREAM_URL, streamUrl)
-    contextType?.let { extras.putString("playback_context_type", it) }
-    contextQuery?.let { extras.putString("playback_context_query", it) }
-    page?.let { extras.putInt("playback_context_page", it) }
+    contextType?.let { extras.putString(PlaybackExtras.KEY_CONTEXT_TYPE, it) }
+    contextQuery?.let { extras.putString(PlaybackExtras.KEY_CONTEXT_QUERY, it) }
+    page?.let { extras.putInt(PlaybackExtras.KEY_CONTEXT_PAGE, it) }
+    contextLat?.let { extras.putDouble(PlaybackExtras.KEY_CONTEXT_LAT, it) }
+    contextLon?.let { extras.putDouble(PlaybackExtras.KEY_CONTEXT_LON, it) }
 
     if (!extras.isEmpty) {
         metadataBuilder.setExtras(extras)

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioPlayerController.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioPlayerController.kt
@@ -1,6 +1,6 @@
 package io.github.agimaulana.radio.core.radioplayer
 
-import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController.PlaybackContext.Type.DEFAULT
+import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController.PlaybackContext.Type.ALL
 import kotlinx.coroutines.flow.Flow
 
 interface RadioPlayerController {
@@ -15,24 +15,24 @@ interface RadioPlayerController {
     fun startPlayback(
         items: List<RadioMediaItem>,
         startIndex: Int = 0,
-        context: PlaybackContext = PlaybackContext(DEFAULT, null)
+        context: PlaybackContext = PlaybackContext(ALL, null, null)
     )
 
     fun setMediaItems(
         items: List<RadioMediaItem>,
         startIndex: Int = 0,
-        context: PlaybackContext = PlaybackContext(DEFAULT, null)
+        context: PlaybackContext = PlaybackContext(ALL, null, null)
     )
 
     fun addMediaItems(
         items: List<RadioMediaItem>,
-        context: PlaybackContext = PlaybackContext(DEFAULT, null)
+        context: PlaybackContext = PlaybackContext(ALL, null, null)
     )
 
     fun addMediaItems(
         index: Int,
         items: List<RadioMediaItem>,
-        context: PlaybackContext = PlaybackContext(DEFAULT, null)
+        context: PlaybackContext = PlaybackContext(ALL, null, null)
     )
 
     fun getPlaylist(): List<RadioMediaItem>
@@ -48,8 +48,10 @@ interface RadioPlayerController {
 
     data class PlaybackContext(
         val type: Type,
-        val query: String? = null
+        val query: String? = null,
+        val location: Location? = null
     ) {
-        enum class Type { DEFAULT, SEARCH, PINNED }
+        data class Location(val latitude: Double, val longitude: Double)
+        enum class Type { ALL, PINNED, SEARCH, LOCATION }
     }
 }

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalog.kt
@@ -3,6 +3,7 @@ package io.github.agimaulana.radio.core.radioplayer.internal
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.CatalogState
@@ -10,9 +11,9 @@ import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
 import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationsUseCase
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.flow.first
 import timber.log.Timber
 
 internal class RadioLibraryCatalog(
@@ -147,6 +148,18 @@ internal class RadioLibraryCatalog(
         return cachedChildren ?: cacheMutex.withLock {
             cachedChildren ?: loadInitialChildren().also { cachedChildren = it }
         }
+    }
+
+    suspend fun getPlaylistForContext(context: RadioPlayerController.PlaybackContext): List<MediaItem> {
+        val source = when (context.type) {
+            RadioPlayerController.PlaybackContext.Type.PINNED -> CatalogState.Source.PINNED
+            RadioPlayerController.PlaybackContext.Type.SEARCH -> CatalogState.Source.SEARCH
+            RadioPlayerController.PlaybackContext.Type.LOCATION -> CatalogState.Source.LOCATION
+            RadioPlayerController.PlaybackContext.Type.ALL -> CatalogState.Source.ALL
+        }
+        val location = context.location?.let { GeoLatLong(it.latitude, it.longitude) }
+        loadInitial(query = context.query, location = location, source = source)
+        return if (source == CatalogState.Source.PINNED) getPinned() else getPlaylist()
     }
 
     suspend fun restore() {
@@ -290,6 +303,8 @@ internal class RadioLibraryCatalog(
                 search = null,
                 location = state.toLocation()
             )
+
+            CatalogState.Source.PINNED -> emptyList()
         }
     }
 

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImpl.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImpl.kt
@@ -47,7 +47,15 @@ internal class RadioPlayerControllerImpl(
         startIndex: Int,
         context: RadioPlayerController.PlaybackContext
     ) {
-        val mediaItems = items.map { it.toMediaItem(context.type.name, context.query, null) }
+        val mediaItems = items.map {
+            it.toMediaItem(
+                contextType = context.type.name,
+                contextQuery = context.query,
+                page = null,
+                contextLat = context.location?.latitude,
+                contextLon = context.location?.longitude,
+            )
+        }
         mediaController.setMediaItems(mediaItems, startIndex, 0L)
     }
 
@@ -55,7 +63,15 @@ internal class RadioPlayerControllerImpl(
         items: List<RadioMediaItem>,
         context: RadioPlayerController.PlaybackContext
     ) {
-        val mediaItems = items.map { it.toMediaItem(context.type.name, context.query, null) }
+        val mediaItems = items.map {
+            it.toMediaItem(
+                contextType = context.type.name,
+                contextQuery = context.query,
+                page = null,
+                contextLat = context.location?.latitude,
+                contextLon = context.location?.longitude,
+            )
+        }
         mediaController.addMediaItems(mediaItems)
     }
 
@@ -68,7 +84,9 @@ internal class RadioPlayerControllerImpl(
             it.toMediaItem(
                 contextType = context.type.name,
                 contextQuery = context.query,
-                page = null
+                page = null,
+                contextLat = context.location?.latitude,
+                contextLon = context.location?.longitude,
             )
         }
         mediaController.addMediaItems(index, mediaItems)

--- a/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
+++ b/core/radioplayer/src/main/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallback.kt
@@ -14,7 +14,9 @@ import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
+import io.github.agimaulana.radio.core.radioplayer.PlaybackExtras
 import io.github.agimaulana.radio.core.radioplayer.RadioLibraryContract
+import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.domain.api.entity.GeoLatLong
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -64,14 +66,18 @@ internal class RadioSessionCallback(
         )
         return callbackScope.future {
             val firstItem = mediaItems.firstOrNull()
+            val context = firstItem?.mediaMetadata?.extras?.let { extractContext(it) }
+
             val (playlist, resolvedIndex) = if (firstItem != null && mediaItems.size == 1) {
-                val catalogPlaylist = radioLibraryCatalog.getPlaylist()
+                val catalogPlaylist = if (context != null) {
+                    radioLibraryCatalog.getPlaylistForContext(context)
+                } else {
+                    radioLibraryCatalog.getPlaylist()
+                }
                 val index = catalogPlaylist.indexOfFirst { it.mediaId == firstItem.mediaId }
                 if (index >= 0) {
                     catalogPlaylist to index
                 } else {
-                    // Item not in catalog (could be a direct ID from an external source)
-                    // Try to find it and build a playlist around it or just use it as is
                     val resolvedItem = radioLibraryCatalog.findChild(firstItem.mediaId) ?: firstItem
                     listOf(resolvedItem) to 0
                 }
@@ -139,8 +145,13 @@ internal class RadioSessionCallback(
         )
 
         return callbackScope.future {
-            val playlist = radioLibraryCatalog.getPlaylist()
             val currentMediaItem = mediaSession.player.currentMediaItem
+            val context = currentMediaItem?.mediaMetadata?.extras?.let { extractContext(it) }
+            val playlist = if (context != null) {
+                radioLibraryCatalog.getPlaylistForContext(context)
+            } else {
+                radioLibraryCatalog.getPlaylist()
+            }
             val startPositionMs = if (isForPlayback) mediaSession.player.currentPosition else C.TIME_UNSET
 
             val (items, index) = if (currentMediaItem != null) {
@@ -252,6 +263,20 @@ internal class RadioSessionCallback(
 
     fun close() {
         callbackScope.cancel()
+    }
+
+    private fun extractContext(extras: Bundle): RadioPlayerController.PlaybackContext? {
+        val typeStr = extras.getString(PlaybackExtras.KEY_CONTEXT_TYPE) ?: return null
+        val type = runCatching { RadioPlayerController.PlaybackContext.Type.valueOf(typeStr) }.getOrNull() ?: return null
+        val query = extras.getString(PlaybackExtras.KEY_CONTEXT_QUERY)
+        val lat = extras.getDouble(PlaybackExtras.KEY_CONTEXT_LAT, Double.NaN).takeIf { !it.isNaN() }
+        val lon = extras.getDouble(PlaybackExtras.KEY_CONTEXT_LON, Double.NaN).takeIf { !it.isNaN() }
+        val location = if (lat != null && lon != null) {
+            RadioPlayerController.PlaybackContext.Location(lat, lon)
+        } else {
+            null
+        }
+        return RadioPlayerController.PlaybackContext(type, query, location)
     }
 
     private companion object {

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItemTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/RadioMediaItemTest.kt
@@ -24,8 +24,33 @@ class RadioMediaItemTest {
         val extras = mediaItem.mediaMetadata.extras
 
         assertNotNull("Extras should not be null", extras)
-        assertEquals("SEARCH", extras?.getString("playback_context_type"))
-        assertEquals("gen", extras?.getString("playback_context_query"))
-        assertEquals(2, extras?.getInt("playback_context_page"))
+        assertEquals("SEARCH", extras?.getString(PlaybackExtras.KEY_CONTEXT_TYPE))
+        assertEquals("gen", extras?.getString(PlaybackExtras.KEY_CONTEXT_QUERY))
+        assertEquals(2, extras?.getInt(PlaybackExtras.KEY_CONTEXT_PAGE))
+    }
+
+    @Test
+    fun toMediaItem_attachesLocationExtras() {
+        val radio = RadioMediaItem(
+            mediaId = "id1",
+            streamUrl = "https://example.com/stream",
+            radioMetadata = RadioMediaItem.RadioMetadata(
+                stationName = "Station One",
+                genre = "Jazz",
+                imageUrl = "https://example.com/image.png"
+            )
+        )
+
+        val mediaItem = radio.toMediaItem(
+            contextType = "LOCATION",
+            contextLat = -6.2,
+            contextLon = 106.8
+        )
+        val extras = mediaItem.mediaMetadata.extras
+
+        assertNotNull("Extras should not be null", extras)
+        assertEquals("LOCATION", extras?.getString(PlaybackExtras.KEY_CONTEXT_TYPE))
+        assertEquals(-6.2, extras?.getDouble(PlaybackExtras.KEY_CONTEXT_LAT) ?: 0.0, 0.001)
+        assertEquals(106.8, extras?.getDouble(PlaybackExtras.KEY_CONTEXT_LON) ?: 0.0, 0.001)
     }
 }

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalogTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioLibraryCatalogTest.kt
@@ -1,5 +1,6 @@
 package io.github.agimaulana.radio.core.radioplayer.internal
 
+import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
 import io.github.agimaulana.radio.domain.api.repository.CatalogState
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
@@ -207,6 +208,69 @@ class RadioLibraryCatalogTest {
                     it.locationLon == location.longitude &&
                     it.page == 0 &&
                     it.source == CatalogState.Source.LOCATION
+            })
+        }
+    }
+
+    @Test
+    fun getPlaylistForContext_searchContext_loadsSearchPlaylist() = runTest {
+        coEvery { catalogStateRepository.load() } returns null
+        coEvery {
+            getRadioStationsUseCase.execute(page = 1, searchName = "jazz", location = null)
+        } returns buildStations(1, 5)
+        coEvery {
+            getRadioStationsUseCase.execute(page = 2, searchName = "jazz", location = null)
+        } returns emptyList()
+
+        val catalog = RadioLibraryCatalog(
+            getRadioStationsUseCase,
+            getPinnedStationsUseCase,
+            getRadioStationUseCase,
+            catalogStateRepository
+        )
+
+        val context = RadioPlayerController.PlaybackContext(
+            type = RadioPlayerController.PlaybackContext.Type.SEARCH,
+            query = "jazz"
+        )
+        val playlist = catalog.getPlaylistForContext(context)
+
+        assertEquals(5, playlist.size)
+        coVerify {
+            catalogStateRepository.save(match {
+                it.query == "jazz" && it.source == CatalogState.Source.SEARCH
+            })
+        }
+    }
+
+    @Test
+    fun getPlaylistForContext_locationContext_loadsLocationPlaylist() = runTest {
+        coEvery { catalogStateRepository.load() } returns null
+        val location = io.github.agimaulana.radio.domain.api.entity.GeoLatLong(-6.2, 106.8)
+        coEvery {
+            getRadioStationsUseCase.execute(page = 1, searchName = null, location = location)
+        } returns buildStations(1, 3)
+        coEvery {
+            getRadioStationsUseCase.execute(page = 2, searchName = null, location = location)
+        } returns emptyList()
+
+        val catalog = RadioLibraryCatalog(
+            getRadioStationsUseCase,
+            getPinnedStationsUseCase,
+            getRadioStationUseCase,
+            catalogStateRepository
+        )
+
+        val context = RadioPlayerController.PlaybackContext(
+            type = RadioPlayerController.PlaybackContext.Type.LOCATION,
+            location = RadioPlayerController.PlaybackContext.Location(-6.2, 106.8)
+        )
+        val playlist = catalog.getPlaylistForContext(context)
+
+        assertEquals(3, playlist.size)
+        coVerify {
+            catalogStateRepository.save(match {
+                it.locationLat == -6.2 && it.locationLon == 106.8 && it.source == CatalogState.Source.LOCATION
             })
         }
     }

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImplTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioPlayerControllerImplTest.kt
@@ -5,7 +5,10 @@ import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem
 import io.github.agimaulana.radio.core.radioplayer.RadioMediaItem.RadioMetadata
 import io.github.agimaulana.radio.core.radioplayer.RadioPlayerController
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verifyOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -37,5 +40,37 @@ class RadioPlayerControllerImplTest {
             mediaController.prepare()
             mediaController.play()
         }
+    }
+
+    @Test
+    fun startPlayback_withLocationContext_attachesLocationExtras() {
+        val controller = RadioPlayerControllerImpl(mediaController)
+        val items = listOf(
+            RadioMediaItem("id-1", "https://example.com/1", RadioMetadata("One", "News", "https://example.com/1.png"))
+        )
+
+        controller.startPlayback(
+            items = items,
+            startIndex = 0,
+            context = RadioPlayerController.PlaybackContext(
+                type = RadioPlayerController.PlaybackContext.Type.LOCATION,
+                location = RadioPlayerController.PlaybackContext.Location(-6.2, 106.8)
+            )
+        )
+
+        val slot = slot<List<androidx.media3.common.MediaItem>>()
+        verifyOrder {
+            mediaController.setMediaItems(capture(slot), 0, 0L)
+            mediaController.prepare()
+            mediaController.play()
+        }
+
+        val mediaItems = slot.captured
+        assertEquals(1, mediaItems.size)
+        val extras = mediaItems[0].mediaMetadata.extras
+        assertNotNull(extras)
+        assertEquals("LOCATION", extras?.getString("playback_context_type"))
+        assertEquals(-6.2, extras?.getDouble("playback_context_lat") ?: 0.0, 0.001)
+        assertEquals(106.8, extras?.getDouble("playback_context_lon") ?: 0.0, 0.001)
     }
 }

--- a/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
+++ b/core/radioplayer/src/test/kotlin/io/github/agimaulana/radio/core/radioplayer/internal/RadioSessionCallbackTest.kt
@@ -1,10 +1,14 @@
 package io.github.agimaulana.radio.core.radioplayer.internal
 
+import android.os.Bundle
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
+import io.github.agimaulana.radio.core.radioplayer.PlaybackExtras
 import io.github.agimaulana.radio.domain.api.entity.RadioStation
+import io.github.agimaulana.radio.domain.api.repository.CatalogState
 import io.github.agimaulana.radio.domain.api.repository.CatalogStateRepository
 import io.github.agimaulana.radio.domain.api.usecase.GetPinnedStationsUseCase
 import io.github.agimaulana.radio.domain.api.usecase.GetRadioStationUseCase
@@ -62,6 +66,49 @@ class RadioSessionCallbackTest {
         assertEquals(1500L, result.startPositionMs)
     }
 
+    @Test
+    fun onSetMediaItems_usesContextFromExtrasForSearchPlaylist() = runTest {
+        val searchStation1 = radioStation(
+            stationUuid = "search-1",
+            name = "Jazz Station",
+            tags = listOf("jazz"),
+            imageUrl = "https://example.com/jazz1.png",
+            url = "https://example.com/jazz1",
+            resolvedUrl = "https://stream.example.com/jazz1"
+        )
+        val searchStation2 = radioStation(
+            stationUuid = "search-2",
+            name = "Jazz Station Two",
+            tags = listOf("jazz"),
+            imageUrl = "https://example.com/jazz2.png",
+            url = "https://example.com/jazz2",
+            resolvedUrl = "https://stream.example.com/jazz2"
+        )
+        val callback = callbackForSearchStations(listOf(searchStation1, searchStation2))
+        val controller = controller()
+        val session = session()
+
+        val extras = Bundle().apply {
+            putString(PlaybackExtras.KEY_CONTEXT_TYPE, "SEARCH")
+            putString(PlaybackExtras.KEY_CONTEXT_QUERY, "jazz")
+        }
+        val mediaItem = MediaItem.Builder()
+            .setMediaId("search-1")
+            .setMediaMetadata(MediaMetadata.Builder().setExtras(extras).build())
+            .build()
+
+        val result = callback.onSetMediaItems(
+            mediaSession = session,
+            controller = controller,
+            mediaItems = listOf(mediaItem),
+            startIndex = 0,
+            startPositionMs = 0L
+        ).get()
+
+        assertEquals(2, result.mediaItems.size)
+        assertEquals("search-1", result.mediaItems[0].mediaId)
+        assertEquals(0, result.startIndex)
+    }
 
     @Test
     fun onPlaybackResumption_returnsFirstCatalogItemWhenNothingIsPlaying() = runTest {
@@ -145,6 +192,29 @@ class RadioSessionCallbackTest {
         every { getPinnedStationsUseCase.execute() } returns kotlinx.coroutines.flow.flowOf(emptyList())
         coEvery { useCase.execute(page = 1, searchName = null, location = null) } returns stations
         coEvery { useCase.execute(page = 2, searchName = null, location = null) } returns emptyList()
+        coEvery { getRadioStationUseCase.execute(any()) } answers {
+            val id = firstArg<String>()
+            stations.first { it.stationUuid == id }
+        }
+        return RadioSessionCallback(
+            RadioLibraryCatalog(
+                useCase,
+                getPinnedStationsUseCase,
+                getRadioStationUseCase,
+                catalogStateRepository
+            )
+        )
+    }
+
+    private fun callbackForSearchStations(stations: List<RadioStation>): RadioSessionCallback {
+        val useCase = mockk<GetRadioStationsUseCase>()
+        val getPinnedStationsUseCase = mockk<GetPinnedStationsUseCase>()
+        val getRadioStationUseCase = mockk<GetRadioStationUseCase>()
+        val catalogStateRepository = mockk<CatalogStateRepository>(relaxed = true)
+        coEvery { catalogStateRepository.load() } returns CatalogState(source = CatalogState.Source.SEARCH, query = "jazz")
+        every { getPinnedStationsUseCase.execute() } returns kotlinx.coroutines.flow.flowOf(emptyList())
+        coEvery { useCase.execute(page = 1, searchName = "jazz", location = null) } returns stations
+        coEvery { useCase.execute(page = 2, searchName = "jazz", location = null) } returns emptyList()
         coEvery { getRadioStationUseCase.execute(any()) } answers {
             val id = firstArg<String>()
             stations.first { it.stationUuid == id }

--- a/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/repository/CatalogStateRepository.kt
+++ b/domain/api/src/main/kotlin/io/github/agimaulana/radio/domain/api/repository/CatalogStateRepository.kt
@@ -13,6 +13,7 @@ data class CatalogState(
         ALL,
         SEARCH,
         LOCATION,
+        PINNED,
     }
 
     fun toLocation(): GeoLatLong? {

--- a/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
+++ b/feature/stationlist/src/main/java/io/github/agimaulana/radio/feature/stationlist/StationListViewModel.kt
@@ -503,14 +503,18 @@ class StationListViewModel @Inject constructor(
     }
 
     private fun UiState.toPlaybackContext(): RadioPlayerController.PlaybackContext {
-        val contextType = if (!filterStationName.isNullOrEmpty()) {
-            RadioPlayerController.PlaybackContext.Type.SEARCH
-        } else {
-            RadioPlayerController.PlaybackContext.Type.DEFAULT
+        val location = currentPosition?.let {
+            RadioPlayerController.PlaybackContext.Location(it.latitude, it.longitude)
+        }
+        val contextType = when {
+            currentPosition != null -> RadioPlayerController.PlaybackContext.Type.LOCATION
+            !filterStationName.isNullOrEmpty() -> RadioPlayerController.PlaybackContext.Type.SEARCH
+            else -> RadioPlayerController.PlaybackContext.Type.ALL
         }
         return RadioPlayerController.PlaybackContext(
             type = contextType,
-            query = filterStationName
+            query = filterStationName,
+            location = location
         )
     }
 


### PR DESCRIPTION
Add Location field and LOCATION type to PlaybackContext, serialize context into MediaItem extras, and use it in RadioSessionCallback to build the correct playlist on setMediaItems and playback resumption. This ensures playlist reconstruction survives process death with the right context (search, location, pinned, or all) instead of relying on implicit state.